### PR TITLE
Swap max-abs operations in cpu version

### DIFF
--- a/qtorch/quant/quant_cpu/quant_cpu.cpp
+++ b/qtorch/quant/quant_cpu/quant_cpu.cpp
@@ -202,13 +202,13 @@ Tensor get_max_entry(Tensor a, int dim)
   else if (dim == 0)
   {
     Tensor input_view = a.view({a.size(0), -1});
-    max_entry = std::get<0>(input_view.max(1, true)).abs().expand_as(input_view).view_as(a).contiguous();
+    max_entry = std::get<0>(input_view.abs().max(1, true)).expand_as(input_view).view_as(a).contiguous();
   }
   else
   {
     Tensor input_transpose = a.transpose(0, dim);
     Tensor input_view = input_transpose.contiguous().view({input_transpose.size(0), -1});
-    Tensor max_transpose = std::get<0>(input_view.max(1, true)).abs().expand_as(input_view).view_as(input_transpose);
+    Tensor max_transpose = std::get<0>(input_view.abs().max(1, true)).expand_as(input_view).view_as(input_transpose);
     max_entry = max_transpose.transpose(dim, 0).contiguous();
   }
   return max_entry;


### PR DESCRIPTION
The `get_max_entry` function in the cpu implementation computes the max entry for each block in different ways, according to the given `dim` value. If `dim = -1` it computes the maximum values on the absolute values, whereas in all other cases (`dim != -1`) it computes the maximum value on the signed values and THEN it computes their absolute values. This inconsistency leads to a greater approximation error, but it is not present in the cuda implementation. 
This PR swaps the max-abs operations in order to compute the maximum values in each block in the same way for all `dim` cases.