### PR TITLE
[#40] Allowing optimizer.step to handle None gradients

### DIFF
--- a/qtorch/optim/optim_low.py
+++ b/qtorch/optim/optim_low.py
@@ -75,6 +75,9 @@ class OptimLP(Optimizer):
         if not self.grad_quant is None:
             for group in self.param_groups:
                 for p in group["params"]:
+                    # None gradient is equivalent to 0 gradient, skip
+                    if p.grad is None:
+                        continue
                     p.grad.data = self.grad_quant(p.grad.data * self.grad_scaling)
 
         # switch acc into weight before stepping
@@ -103,6 +106,9 @@ class OptimLP(Optimizer):
                 if isinstance(self.optim, SGD) and group["momentum"] == 0:
                     continue
                 for p in group["params"]:
+                    # None gradient is equivalent to 0 gradient, skip
+                    if p.grad is None:
+                        continue
                     param_state = self.optim.state[p]
                     for key in self.momentum_keys:
                         param_state[key] = self.momentum_quant(param_state[key])


### PR DESCRIPTION
if `p.grad` is `None`, `optimizer.step` should not crash. It should instead consider it as a 0 gradient and skip computation like
the default pytorch optimizer. Adding that fix here.