### PR TITLE
Float subnormal support

### DIFF
--- a/README.md
+++ b/README.md
@@ -93,3 +93,7 @@ See our [readthedocs](https://qpytorch.readthedocs.io/en/latest/) page.
 * Zhiqiu Lin
 * [Guandao Yang](http://www.guandaoyang.com/)
 * [Christopher De Sa](http://www.cs.cornell.edu/~cdesa/)
+
+## Other Contributors
+* [Daniel Holanda Noronha](https://www.linkedin.com/in/danielholandanoronha/)
+

--- a/qtorch/quant/quant_cpu/bit_helper.cpp
+++ b/qtorch/quant/quant_cpu/bit_helper.cpp
@@ -1,4 +1,5 @@
 #include "quant_cpu.h"
+#include "stdio.h"
 
 unsigned int clip_exponent(int exp_bits, int man_bits,
                            unsigned int old_num,
@@ -8,29 +9,14 @@ unsigned int clip_exponent(int exp_bits, int man_bits,
     return quantized_num;
 
   int quantized_exponent_store = quantized_num << 1 >> 1 >> 23; // 1 sign bit, 23 mantissa bits
-  int min_exponent_store = -((1 << (exp_bits - 1)) - 1) + 127;
-  int max_exponent_store = ((1 << (exp_bits - 1)) - 1) + 127; // excluding the exponent for infinity
+  int max_exponent_store = (1 << (exp_bits - 1)) + 127; // we are not reserving an exponent bit for infinity, nan, etc
+  // Clippping Value Up
   if (quantized_exponent_store > max_exponent_store)
   {
     unsigned int max_man = (unsigned int)-1 << 9 >> 9 >> (23 - man_bits) << (23 - man_bits); // 1 sign bit, 8 exponent bits, 1 virtual bit
     unsigned int max_num = ((unsigned int)max_exponent_store << 23) | max_man;
     unsigned int old_sign = old_num >> 31 << 31;
     quantized_num = old_sign | max_num;
-  }
-  else if (quantized_exponent_store < min_exponent_store)
-  {
-    unsigned int min_num = ((unsigned int)min_exponent_store << 23);
-    unsigned int middle_num = ((unsigned int)(min_exponent_store - 1) << 23);
-    unsigned int unsigned_quantized_num = quantized_num << 1 >> 1;
-    if (unsigned_quantized_num > middle_num)
-    {
-      unsigned int old_sign = old_num >> 31 << 31;
-      quantized_num = old_sign | min_num;
-    }
-    else
-    {
-      quantized_num = 0;
-    }
   }
   return quantized_num;
 }
@@ -49,8 +35,3 @@ unsigned int clip_max_exponent(int man_bits,
   }
   return quantized_num;
 }
-// unsigned int extract_exponent(float *a) {
-//   unsigned int temp = *(reinterpret_cast<unsigned int*>(a));
-//   temp = (temp << 1 >> 24); // single precision, 1 sign bit, 23 mantissa bits
-//   return temp-127+1; // exponent offset and virtual bit
-// }

--- a/qtorch/quant/quant_cpu/quant_cpu.cpp
+++ b/qtorch/quant/quant_cpu/quant_cpu.cpp
@@ -4,6 +4,7 @@
 #include <tuple>
 #include "quant_cpu.h"
 
+
 using namespace at;
 
 enum Mode
@@ -40,6 +41,23 @@ T clamp_helper(T a, T min, T max)
     return min;
   else
     return a;
+}
+
+void printBits(size_t const size, void const * const ptr)
+{
+    unsigned char *b = (unsigned char*) ptr;
+    unsigned char byte;
+    int i, j;
+    
+    for (i = size-1; i >= 0; i--) {
+        for (j = 7; j >= 0; j--) {
+
+            byte = (b[i] >> j) & 1;
+            printf("%u", byte);
+            if ((i==size-1 && j==7) || (i==size-2 && j==7))
+              printf(" ");
+        }
+    }
 }
 
 template <typename T>
@@ -147,6 +165,7 @@ Tensor fixed_point_quantize_nearest(Tensor a, int wl, int fl, bool clamp, bool s
 
 unsigned int round_bitwise(unsigned int target, int man_bits, Mode rounding)
 {
+  
   unsigned int mask = (1 << (23 - man_bits)) - 1;
   unsigned int rand_prob;
   if (rounding == rStochastic)
@@ -275,12 +294,28 @@ Tensor float_quantize_nearest(Tensor a, int man_bits, int exp_bits)
 
   for (int64_t i = 0; i < size; i++)
   {
-    unsigned int target;
+    unsigned int target,quantize_bits;
     FLOAT_TO_BITS(a_array[i], target);
-    unsigned int quantize_bits = round_bitwise(target, man_bits, rNearest);
-    quantize_bits = clip_exponent(exp_bits, man_bits, target, quantize_bits);
     float quantized;
-    BITS_TO_FLOAT(quantize_bits, quantized);
+
+    int target_exp = (target << 1 >> 1 >> 23) -127; 
+    int min_exp = -((1 << (exp_bits - 1)) - 2);
+    bool subnormal = (target_exp < min_exp);
+    if (subnormal){
+      float shift_float,val;
+      int shift_bits = ((127+min_exp)<<23) | (target >> 31 <<31);
+      BITS_TO_FLOAT(shift_bits, shift_float);
+      val=a_array[i]+shift_float;
+      FLOAT_TO_BITS(val, target);
+      quantize_bits = round_bitwise(target, man_bits, rNearest);
+      BITS_TO_FLOAT(quantize_bits, quantized);
+      quantized=quantized-shift_float;
+    }
+    else{
+      quantize_bits = round_bitwise(target, man_bits, rNearest);
+      quantize_bits = clip_exponent(exp_bits, man_bits, target, quantize_bits);
+      BITS_TO_FLOAT(quantize_bits, quantized);
+    }
     o_array[i] = quantized;
   }
   return o;

--- a/qtorch/quant/quant_cuda/bit_helper.cu
+++ b/qtorch/quant/quant_cuda/bit_helper.cu
@@ -28,27 +28,18 @@ __device__ __forceinline__ unsigned int round_bitwise_nearest(unsigned int targe
 __device__ __forceinline__ unsigned int clip_exponent(int exp_bits, int man_bits,
                                                       unsigned int old_num,
                                                       unsigned int quantized_num) {
+  if (quantized_num == 0)
+    return quantized_num;
+
   int quantized_exponent_store = quantized_num << 1 >> 1 >> 23; // 1 sign bit, 23 mantissa bits
-  int min_exponent_store = -((1 << (exp_bits-1))-1) + 127;
-  int max_exponent_store = ((1 << (exp_bits-1))-1) + 127; // excluding the exponent for infinity
-  if (quantized_exponent_store > max_exponent_store) {
-    unsigned int max_man = (unsigned int ) -1 << 9 >> 9 >> (23-man_bits) << (23-man_bits); // 1 sign bit, 8 exponent bits, 1 virtual bit
-    unsigned int max_num = ((unsigned int) max_exponent_store << 23) | max_man;
+  int max_exponent_store = (1 << (exp_bits - 1)) + 127; // we are not reserving an exponent bit for infinity, nan, etc
+  // Clippping Value Up
+  if (quantized_exponent_store > max_exponent_store)
+  {
+    unsigned int max_man = (unsigned int)-1 << 9 >> 9 >> (23 - man_bits) << (23 - man_bits); // 1 sign bit, 8 exponent bits, 1 virtual bit
+    unsigned int max_num = ((unsigned int)max_exponent_store << 23) | max_man;
     unsigned int old_sign = old_num >> 31 << 31;
     quantized_num = old_sign | max_num;
-  } else if (quantized_exponent_store < min_exponent_store) {
-    unsigned int min_num = ((unsigned int)min_exponent_store << 23);
-    unsigned int middle_num = ((unsigned int)(min_exponent_store - 1) << 23);
-    unsigned int unsigned_quantized_num = quantized_num << 1 >> 1;
-    if (unsigned_quantized_num > middle_num)
-    {
-      unsigned int old_sign = old_num >> 31 << 31;
-      quantized_num = old_sign | min_num;
-    }
-    else
-    {
-      quantized_num = 0;
-    }
   }
   return quantized_num;
 }

--- a/qtorch/quant/quant_cuda/float_kernel.cu
+++ b/qtorch/quant/quant_cuda/float_kernel.cu
@@ -10,12 +10,35 @@ __global__ void float_kernel_stochastic(float* __restrict__ a,
                                         int exp_bits) {
   int index = blockIdx.x * blockDim.x + threadIdx.x;
   if (index < size) {
-    unsigned int old_num = FLOAT_TO_BITS(&a[index]);
+    //unsigned int old_num = FLOAT_TO_BITS(&a[index]);
+    //unsigned int rand_prob = (unsigned int) r[index];
+    //unsigned int quantize = round_bitwise_stochastic(old_num, rand_prob, man_bits);
+    //quantize = clip_exponent(exp_bits, man_bits, old_num, quantize);
+    //float quantize_float = BITS_TO_FLOAT(&quantize);
+    //o[index] = quantize_float;
     unsigned int rand_prob = (unsigned int) r[index];
-    unsigned int quantize = round_bitwise_stochastic(old_num, rand_prob, man_bits);
-    quantize = clip_exponent(exp_bits, man_bits, old_num, quantize);
-    float quantize_float = BITS_TO_FLOAT(&quantize);
-    o[index] = quantize_float;
+    unsigned int target,quantize_bits;
+    target = FLOAT_TO_BITS(&a[index]);
+    float quantized;
+
+    int target_exp = (target << 1 >> 1 >> 23) -127; 
+    int min_exp = -((1 << (exp_bits - 1)) - 2);
+    bool subnormal = (target_exp < min_exp);
+    if (subnormal){
+      float shift_float,val;
+      int shift_bits = ((127+min_exp)<<23) | (target >> 31 <<31);
+      shift_float = BITS_TO_FLOAT(&shift_bits);
+      val=a[index]+shift_float;
+      target = FLOAT_TO_BITS(&val);
+      quantize_bits = round_bitwise_stochastic(target, rand_prob, man_bits);
+      quantized = BITS_TO_FLOAT(&quantize_bits) - shift_float;
+    }
+    else{
+      quantize_bits = round_bitwise_stochastic(target, rand_prob, man_bits);
+      quantize_bits = clip_exponent(exp_bits, man_bits, target, quantize_bits);
+      quantized = BITS_TO_FLOAT(&quantize_bits);
+    }
+    o[index] = quantized;
   }
 }
 
@@ -27,10 +50,33 @@ __global__ void float_kernel_nearest(float* __restrict__ a,
                                      int exp_bits) {
   int index = blockIdx.x * blockDim.x + threadIdx.x;
   if (index < size) {
-    unsigned int old_num = FLOAT_TO_BITS(&a[index]);
-    unsigned int quantize = round_bitwise_nearest(old_num, man_bits);
-    quantize = clip_exponent(exp_bits, man_bits, old_num, quantize);
-    float quantize_float = BITS_TO_FLOAT(&quantize);
-    o[index] = quantize_float;
+
+    //unsigned int old_num = FLOAT_TO_BITS(&a[index]);
+    //unsigned int quantize = round_bitwise_nearest(old_num, man_bits);
+    //quantize = clip_exponent(exp_bits, man_bits, old_num, quantize);
+    //float quantize_float = BITS_TO_FLOAT(&quantize);
+    //o[index] = quantize_float;
+    unsigned int target,quantize_bits;
+    target = FLOAT_TO_BITS(&a[index]);
+    float quantized;
+
+    int target_exp = (target << 1 >> 1 >> 23) -127; 
+    int min_exp = -((1 << (exp_bits - 1)) - 2);
+    bool subnormal = (target_exp < min_exp);
+    if (subnormal){
+      float shift_float,val;
+      int shift_bits = ((127+min_exp)<<23) | (target >> 31 <<31);
+      shift_float = BITS_TO_FLOAT(&shift_bits);
+      val=a[index]+shift_float;
+      target = FLOAT_TO_BITS(&val);
+      quantize_bits = round_bitwise_nearest(target, man_bits);
+      quantized = BITS_TO_FLOAT(&quantize_bits) - shift_float;
+    }
+    else{
+      quantize_bits = round_bitwise_nearest(target, man_bits);
+      quantize_bits = clip_exponent(exp_bits, man_bits, target, quantize_bits);
+      quantized = BITS_TO_FLOAT(&quantize_bits);
+    }
+    o[index] = quantized;
   }
 }

--- a/qtorch/quant/quant_cuda/float_kernel.cu
+++ b/qtorch/quant/quant_cuda/float_kernel.cu
@@ -10,12 +10,6 @@ __global__ void float_kernel_stochastic(float* __restrict__ a,
                                         int exp_bits) {
   int index = blockIdx.x * blockDim.x + threadIdx.x;
   if (index < size) {
-    //unsigned int old_num = FLOAT_TO_BITS(&a[index]);
-    //unsigned int rand_prob = (unsigned int) r[index];
-    //unsigned int quantize = round_bitwise_stochastic(old_num, rand_prob, man_bits);
-    //quantize = clip_exponent(exp_bits, man_bits, old_num, quantize);
-    //float quantize_float = BITS_TO_FLOAT(&quantize);
-    //o[index] = quantize_float;
     unsigned int rand_prob = (unsigned int) r[index];
     unsigned int target,quantize_bits;
     target = FLOAT_TO_BITS(&a[index]);
@@ -50,12 +44,6 @@ __global__ void float_kernel_nearest(float* __restrict__ a,
                                      int exp_bits) {
   int index = blockIdx.x * blockDim.x + threadIdx.x;
   if (index < size) {
-
-    //unsigned int old_num = FLOAT_TO_BITS(&a[index]);
-    //unsigned int quantize = round_bitwise_nearest(old_num, man_bits);
-    //quantize = clip_exponent(exp_bits, man_bits, old_num, quantize);
-    //float quantize_float = BITS_TO_FLOAT(&quantize);
-    //o[index] = quantize_float;
     unsigned int target,quantize_bits;
     target = FLOAT_TO_BITS(&a[index]);
     float quantized;

--- a/test/test_clamp.py
+++ b/test/test_clamp.py
@@ -3,6 +3,9 @@ import unittest
 from qtorch.quant import *
 from qtorch import FixedPoint, BlockFloatingPoint, FloatingPoint
 
+DEBUG = False
+
+log = lambda m: print(m) if DEBUG else False
 
 class TestStochastic(unittest.TestCase):
     """
@@ -12,7 +15,8 @@ class TestStochastic(unittest.TestCase):
 
     def test_fixed(self):
         """test fixed point clamping"""
-        for d in ["cpu", "cuda"]:
+        #for d in ["cpu", "cuda"]:
+        for d in ["cpu"]:
             for r in ["stochastic", "nearest"]:
                 wl = 5
                 fl = 4
@@ -29,30 +33,52 @@ class TestStochastic(unittest.TestCase):
                 self.assertGreater(t_min, no_clamp_a.min().item())
 
     def test_float(self):
-        """test floating point clamping"""
-        formats = [(6, 9), (5, 10), (5, 2)]
+        """test floating point quantization"""
+        formats = [(2,2),(2,3),(3,2)]
 
         for exp, man in formats:
-            for d in ["cpu", "cuda"]:
+            #for d in ["cpu", "cuda"]:
+            for d in ["cpu"]:
                 for r in ["stochastic", "nearest"]:
-                    # test positive
                     a_max = 2 ** (2 ** (exp - 1)) * (1 - 2 ** (-man - 1))
                     a_min = 2 ** (-(2 ** (exp - 1)) + 1)
-                    a = torch.Tensor([2 ** 50, a_min * 0.75, 2 ** (-50)]).to(device=d)
-                    quant_a = float_quantize(a, exp=exp, man=man, rounding=r)
-                    self.assertEqual(quant_a[0].item(), a_max)
-                    self.assertAlmostEqual(quant_a[1].item(), a_min)
-                    self.assertAlmostEqual(quant_a[2].item(), 0)
+                    max_exp=int((2**exp)/2)
+                    min_exp=-(max_exp-2)
+                    mantissa_step=2**(-man)
+                    min_mantissa=mantissa_step   # When denormalized
+                    max_mantissa=2-mantissa_step # When normalized, mantissa goes from 1 to 2-mantissa_step
+                    a_min = 2**min_exp*min_mantissa
+                    a_max = 2**max_exp*max_mantissa
+                    expected_vals=[]
+                    log(f"With {exp} exponent bits, our exponent goes from {min_exp} to {max_exp}")
+                    log(f"With {man} mantissa bits, our mantissa goes from {min_mantissa} (denormalized) to {max_mantissa}")
+                    log(f"With {man} mantissa bits and {exp} exponent bits, we can go from {a_min} to {a_max}")
+                    representable_normalized =[]
+                    for sign in [1,-1]:
+                        for e in range(0,2**exp):
+                            for m in range(0,2**man):
+                                if e==0:
+                                    val = sign*(2**(e+min_exp)*m*2**(-man))
+                                    log(f"{0 if sign==1 else 1} {e:0{exp}b} {m:0{man}b} = {sign} * 2^{e+min_exp} * {m*2**(-man)} \t= {val} (denormalized)")
+                                else:
+                                    val = sign*(2**(e+min_exp-1)*(1+(m*2**(-man))))
+                                    log(f"{0 if sign==1 else 1} {e:0{exp}b} {m:0{man}b} = {sign} * 2^{e+min_exp-1} * {1+(m*2**(-man))} \t= {val}")
+                                if val not in expected_vals:
+                                    expected_vals.append(val)
+                    expected_vals.sort()
+                    
+                    # Block box test to get representable numbers
+                    import numpy as np
+                    quant_vals=[]
+                    for i in np.arange(-30,30,.01):
+                        a = torch.Tensor([i]).to(device=d)
+                        quant_a = float_quantize(a, exp=exp, man=man, rounding=r)
+                        if quant_a[0] not in quant_vals:
+                            quant_vals.append(quant_a[0].item())
+                    log("Values representable in QPytorch")
+                    log(quant_vals)
 
-                    # test negative
-                    a_max = -(2 ** (2 ** (exp - 1))) * (1 - 2 ** (-man - 1))
-                    a_min = -(2 ** (-(2 ** (exp - 1)) + 1))
-                    a = torch.Tensor([-(2 ** 50), a_min * 0.75, -(2 ** (-50))]).to(device=d)
-                    quant_a = float_quantize(a, exp=exp, man=man, rounding=r)
-                    self.assertEqual(quant_a[0].item(), a_max)
-                    self.assertAlmostEqual(quant_a[1].item(), a_min)
-                    self.assertAlmostEqual(quant_a[2].item(), 0)
-
+                    self.assertEqual(quant_vals, expected_vals)
 
 if __name__ == "__main__":
     unittest.main()

--- a/test/test_clamp.py
+++ b/test/test_clamp.py
@@ -15,8 +15,7 @@ class TestStochastic(unittest.TestCase):
 
     def test_fixed(self):
         """test fixed point clamping"""
-        #for d in ["cpu", "cuda"]:
-        for d in ["cpu"]:
+        for d in ["cpu", "cuda"]:
             for r in ["stochastic", "nearest"]:
                 wl = 5
                 fl = 4
@@ -37,8 +36,7 @@ class TestStochastic(unittest.TestCase):
         formats = [(2,2),(2,3),(3,2)]
 
         for exp, man in formats:
-            #for d in ["cpu", "cuda"]:
-            for d in ["cpu"]:
+            for d in ["cpu", "cuda"]:
                 for r in ["stochastic", "nearest"]:
                     a_max = 2 ** (2 ** (exp - 1)) * (1 - 2 ** (-man - 1))
                     a_min = 2 ** (-(2 ** (exp - 1)) + 1)


### PR DESCRIPTION
This PR adds support for subnormal numbers in QPyTorch when using floating-point.

Before this PR, floating-point numbers would not represent well numbers close to zero.

Here is an example of how numbers are now handled when using 2 exponent bits and 2 mantissa bits:

0 00 00 = 1 * 2^0 * 0.0 	= 0.0 (denormalized)
0 00 01 = 1 * 2^0 * 0.25 	= 0.25 (denormalized)
0 00 10 = 1 * 2^0 * 0.5 	= 0.5 (denormalized)
0 00 11 = 1 * 2^0 * 0.75 	= 0.75 (denormalized)
0 01 00 = 1 * 2^0 * 1.0 	= 1.0
0 01 01 = 1 * 2^0 * 1.25 	= 1.25
0 01 10 = 1 * 2^0 * 1.5 	= 1.5
0 01 11 = 1 * 2^0 * 1.75 	= 1.75
0 10 00 = 1 * 2^1 * 1.0 	= 2.0
0 10 01 = 1 * 2^1 * 1.25 	= 2.5
0 10 10 = 1 * 2^1 * 1.5 	= 3.0
0 10 11 = 1 * 2^1 * 1.75 	= 3.5
0 11 00 = 1 * 2^2 * 1.0 	= 4.0
0 11 01 = 1 * 2^2 * 1.25 	= 5.0
0 11 10 = 1 * 2^2 * 1.5 	= 6.0
0 11 11 = 1 * 2^2 * 1.75 	= 7.0
1 00 00 = -1 * 2^0 * 0.0 	= -0.0 (denormalized)
1 00 01 = -1 * 2^0 * 0.25 = -0.25 (denormalized)
1 00 10 = -1 * 2^0 * 0.5 	= -0.5 (denormalized)
1 00 11 = -1 * 2^0 * 0.75 	= -0.75 (denormalized)
1 01 00 = -1 * 2^0 * 1.0 	= -1.0
1 01 01 = -1 * 2^0 * 1.25 	= -1.25
1 01 10 = -1 * 2^0 * 1.5 	= -1.5
1 01 11 = -1 * 2^0 * 1.75 	= -1.75
1 10 00 = -1 * 2^1 * 1.0 	= -2.0
1 10 01 = -1 * 2^1 * 1.25 	= -2.5
1 10 10 = -1 * 2^1 * 1.5 	= -3.0
1 10 11 = -1 * 2^1 * 1.75 	= -3.5
1 11 00 = -1 * 2^2 * 1.0 	= -4.0
1 11 01 = -1 * 2^2 * 1.25 	= -5.0
1 11 10 = -1 * 2^2 * 1.5 	= -6.0
1 11 11 = -1 * 2^2 * 1.75 	= -7.0

The tenst_clamp.py test has also been redesigned to thoroughly test all numbers representable by QPyTorch in different scenarios. To check representable numbers, set DEBUG to True.