### PR TITLE
Device setting bugs on multi-GPU environments

### DIFF
--- a/qtorch/quant/quant_cuda/quant.cu
+++ b/qtorch/quant/quant_cuda/quant.cu
@@ -28,6 +28,7 @@ Tensor get_max_entry(Tensor a, int dim) {
 }
 
 Tensor block_quantize_stochastic_cuda(Tensor a, int wl, int dim) {
+  cudaSetDevice(a.get_device());
   auto o = at::zeros_like(a);
   auto rand_ints = randint_like(a, INT_MAX, device(kCUDA).dtype(kInt));
   int64_t size = a.numel();
@@ -46,6 +47,7 @@ Tensor block_quantize_stochastic_cuda(Tensor a, int wl, int dim) {
 }
 
 Tensor block_quantize_nearest_cuda(Tensor a, int wl, int dim) {
+  cudaSetDevice(a.get_device());
   auto o = at::zeros_like(a);
   int64_t size = a.numel();
 
@@ -62,6 +64,7 @@ Tensor block_quantize_nearest_cuda(Tensor a, int wl, int dim) {
 }
 
 Tensor block_quantize_sim_stochastic_cuda(Tensor a, int wl) {
+  cudaSetDevice(a.get_device());
   auto o = at::zeros_like(a);
   auto rand_probs = rand_like(a);
   int64_t size = a.numel();
@@ -80,6 +83,7 @@ Tensor block_quantize_sim_stochastic_cuda(Tensor a, int wl) {
 }
 
 Tensor block_quantize_sim_nearest_cuda(Tensor a, int wl) {
+  cudaSetDevice(a.get_device());
   auto o = at::zeros_like(a);
   auto rand_ints = randint_like(a, INT_MAX, device(kCUDA).dtype(kInt));
   int64_t size = a.numel();
@@ -98,6 +102,7 @@ Tensor block_quantize_sim_nearest_cuda(Tensor a, int wl) {
 
 Tensor float_quantize_stochastic_cuda(Tensor a, int man_bits, int exp_bits) {
   // use external random number right now
+  cudaSetDevice(a.get_device());
   auto o = zeros_like(a);
   auto rand_ints = randint_like(a, INT_MAX, device(kCUDA).dtype(kInt));
   int size = a.numel();
@@ -115,6 +120,7 @@ Tensor float_quantize_stochastic_cuda(Tensor a, int man_bits, int exp_bits) {
 
 Tensor float_quantize_nearest_cuda(Tensor a, int man_bits, int exp_bits) {
   // use external random number right now
+  cudaSetDevice(a.get_device());
   auto o = zeros_like(a);
   int size = a.numel();
   int blockSize = 1024;
@@ -137,6 +143,7 @@ void fixed_min_max(int wl, int fl, bool symmetric, float* t_min, float* t_max) {
 
 Tensor fixed_point_quantize_stochastic_cuda(Tensor a, int wl, int fl, bool use_clamp, bool symmetric) {
   // use external random number right now
+  cudaSetDevice(a.get_device());
   auto o = at::zeros_like(a);
   auto rand_probs = rand_like(a);
   int64_t size = a.numel();
@@ -159,6 +166,7 @@ Tensor fixed_point_quantize_stochastic_cuda(Tensor a, int wl, int fl, bool use_c
 
 Tensor fixed_point_quantize_nearest_cuda(Tensor a, int wl, int fl, bool use_clamp, bool symmetric) {
   // use external random number right now
+  cudaSetDevice(a.get_device());
   auto o = at::zeros_like(a);
   int64_t size = a.numel();
   int sigma = -fl;
@@ -179,6 +187,7 @@ Tensor fixed_point_quantize_nearest_cuda(Tensor a, int wl, int fl, bool use_clam
 
 std::tuple<Tensor, Tensor> fixed_point_quantize_stochastic_mask_cuda(Tensor a, int wl, int fl, bool symmetric) {
   // use external random number right now
+  cudaSetDevice(a.get_device());
   auto o = zeros_like(a);
   auto rand_probs = rand_like(a);
   auto m = zeros_like(a, a.options().dtype(kByte));
@@ -202,6 +211,7 @@ std::tuple<Tensor, Tensor> fixed_point_quantize_stochastic_mask_cuda(Tensor a, i
 
 std::tuple<Tensor, Tensor> fixed_point_quantize_nearest_mask_cuda(Tensor a, int wl, int fl, bool symmetric) {
   // use external random number right now
+  cudaSetDevice(a.get_device());
   auto o = at::zeros_like(a);
   auto m = zeros_like(a, a.options().dtype(kByte));
   int64_t size = a.numel();

--- a/test/test_device.py
+++ b/test/test_device.py
@@ -16,53 +16,56 @@ class TestDevice(unittest.TestCase):
     def test_fixed_point(self):
         for wl, fl in [(5, 4), (3, 2)]:
             for rounding in ["nearest"]:
-                t_max = 1 - (2 ** (-fl))
-                to_quantize_cuda = torch.linspace(
-                    -t_max, t_max, steps=20, device="cuda"
-                )
-                to_quantize_cpu = to_quantize_cuda.clone().to("cpu")
-                fixed_quantized_cuda = fixed_point_quantize(
-                    to_quantize_cuda, wl=wl, fl=fl, rounding=rounding
-                )
-                fixed_quantized_cpu = fixed_point_quantize(
-                    to_quantize_cpu, wl=wl, fl=fl, rounding=rounding
-                )
-                mse = self.error(fixed_quantized_cuda, fixed_quantized_cpu)
-                self.assertTrue(mse < 1e-15)
-                # self.assertTrue(torch.eq(fixed_quantized_cuda.cpu(), fixed_quantized_cpu).all().item())
+                for device in [("cuda:%d" % d) for d in range(torch.cuda.device_count())]:
+                    t_max = 1 - (2 ** (-fl))
+                    to_quantize_cuda = torch.linspace(
+                        -t_max, t_max, steps=1200, device=torch.device(device)
+                    )
+                    to_quantize_cpu = to_quantize_cuda.clone().to("cpu")
+                    fixed_quantized_cuda = fixed_point_quantize(
+                        to_quantize_cuda, wl=wl, fl=fl, rounding=rounding
+                    )
+                    fixed_quantized_cpu = fixed_point_quantize(
+                        to_quantize_cpu, wl=wl, fl=fl, rounding=rounding
+                    )
+                    mse = self.error(fixed_quantized_cuda, fixed_quantized_cpu)
+                    self.assertTrue(mse < 1e-15, msg="%.2e MSE on device '%s'" % (mse, device))
+                    # self.assertTrue(torch.eq(fixed_quantized_cuda.cpu(), fixed_quantized_cpu).all().item())
 
     def test_block_floating_point(self):
         for wl in [5, 3]:
             for rounding in ["nearest"]:
                 for dim in [-1, 0, 1]:
-                    t_max = 1 - (2 ** (-4))
-                    to_quantize_cuda = torch.linspace(
-                        -t_max, t_max, steps=20, device="cuda"
-                    )
-                    to_quantize_cpu = to_quantize_cuda.clone().to("cpu")
-                    block_quantized_cuda = block_quantize(
-                        to_quantize_cuda, wl=wl, rounding=rounding
-                    )
-                    block_quantized_cpu = block_quantize(
-                        to_quantize_cpu, wl=wl, rounding=rounding
-                    )
-                    mse = self.error(block_quantized_cuda, block_quantized_cpu)
-                    self.assertTrue(mse < 1e-15)
-                    # self.assertTrue(torch.eq(block_quantized_cuda.cpu(), block_quantized_cpu).all().item())
+                    for device in [("cuda:%d" % d) for d in range(torch.cuda.device_count())]:
+                        t_max = 1 - (2 ** (-4))
+                        to_quantize_cuda = torch.linspace(
+                            -t_max, t_max, steps=1200, device=torch.device(device)
+                        )
+                        to_quantize_cpu = to_quantize_cuda.clone().to("cpu")
+                        block_quantized_cuda = block_quantize(
+                            to_quantize_cuda, wl=wl, rounding=rounding
+                        )
+                        block_quantized_cpu = block_quantize(
+                            to_quantize_cpu, wl=wl, rounding=rounding
+                        )
+                        mse = self.error(block_quantized_cuda, block_quantized_cpu)
+                        self.assertTrue(mse < 1e-15, msg="%.2e MSE on device '%s'" % (mse, device))
+                        # self.assertTrue(torch.eq(block_quantized_cuda.cpu(), block_quantized_cpu).all().item())
 
     def test_floating_point(self):
         for man, exp in [(2, 5), (6, 9)]:
             for rounding in ["nearest"]:
-                to_quantize_cuda = torch.rand(20).cuda()
-                to_quantize_cpu = to_quantize_cuda.clone().to("cpu")
-                float_quantized_cuda = float_quantize(
-                    to_quantize_cuda, man=man, exp=exp, rounding=rounding
-                )
-                float_quantized_cpu = float_quantize(
-                    to_quantize_cpu, man=man, exp=exp, rounding=rounding
-                )
-                mse = self.error(float_quantized_cuda, float_quantized_cpu)
-                self.assertTrue(mse < 1e-15)
+                for device in [("cuda:%d" % d) for d in range(torch.cuda.device_count())]:
+                    to_quantize_cuda = torch.rand(1200).to(torch.device(device))
+                    to_quantize_cpu = to_quantize_cuda.clone().to("cpu")
+                    float_quantized_cuda = float_quantize(
+                        to_quantize_cuda, man=man, exp=exp, rounding=rounding
+                    )
+                    float_quantized_cpu = float_quantize(
+                        to_quantize_cpu, man=man, exp=exp, rounding=rounding
+                    )
+                    mse = self.error(float_quantized_cuda, float_quantized_cpu)
+                    self.assertTrue(mse < 1e-15, msg="%.2e MSE on device '%s'" % (mse, device))
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
## Summary

Fixes the CUDA memory bugs on multi-GPU environments by adding `cudaSetDevice()`.
The unit tests are also updated.


## Background

The version on PyPI caused a CUDA illegal memory access error on my machine with 2 GPUs.
When using a GPU other than `torch.device("cuda:0")` or simply `.cuda()`, we need to call `cudaSetDevice()` before allocating the output Tensor and calling the kernel.
(This is not described in PyTorch's official documentation, and I also experienced similar bugs in my own codes 🤪)

This PR includes the addition of `cudaSetDevice()` calling, as well as improved test cases that can detect these kinds of bugs.


## Problem

### Environment

- PyTorch 1.7.0 and 1.8.0
- QPyTorch 0.3.0 installed via pip
- CUDA 11.1

### Symptom

When I used a CUDA device `"cuda:1"` instead of `"cuda:0"`, the below CUDA error occurred in a specific epoch.
CUDA memory errors occur not always at the exact problematic code itself, probably since the CUDA operations are pipelined using multiple Streams.

```
Traceback (most recent call last):
  File "main.py", line 145, in <module>
    train_loss = train(epoch)
  File "main.py", line 85, in train
    outputs = model(images)
  File "/opt/conda/lib/python3.6/site-packages/torch/nn/modules/module.py", line 727, in _call_impl
    result = self.forward(*input, **kwargs)
  File "main.py", line 71, in forward
    x = self.relu(self.bn1(self.conv1(x)))
  File "/opt/conda/lib/python3.6/site-packages/torch/nn/modules/module.py", line 727, in _call_impl
    result = self.forward(*input, **kwargs)
  File "/opt/conda/lib/python3.6/site-packages/torch/nn/modules/batchnorm.py", line 111, in forward
    self.num_batches_tracked = self.num_batches_tracked + 1
RuntimeError: CUDA error: an illegal memory access was encountered
```


## Solution

I added the `cudaSetDevice()` calling to `quant.cu`.

The unit test `test_device.py` is also improved so that it can detect this bug.

When the test is ran using the older code on my machine with 2 GPUs, it *correctly fails* with the following message:

```
FEE
======================================================================
ERROR: test_fixed_point (__main__.TestDevice)
----------------------------------------------------------------------
Traceback (most recent call last):
  File "test_device.py", line 24, in test_fixed_point
    to_quantize_cpu = to_quantize_cuda.clone().to("cpu")
RuntimeError: CUDA error: an illegal memory access was encountered

======================================================================
ERROR: test_floating_point (__main__.TestDevice)
----------------------------------------------------------------------
Traceback (most recent call last):
  File "test_device.py", line 59, in test_floating_point
    to_quantize_cuda = torch.rand(1200).to(torch.device(device))
RuntimeError: CUDA error: an illegal memory access was encountered

======================================================================
FAIL: test_block_floating_point (__main__.TestDevice)
----------------------------------------------------------------------
Traceback (most recent call last):
  File "test_device.py", line 52, in test_block_floating_point
    self.assertTrue(mse < 1e-15, msg="%.2e MSE on device '%s'" % (mse, device))
AssertionError: False is not true : 3.52e+02 MSE on device 'cuda:1'

----------------------------------------------------------------------
Ran 3 tests in 2.222s

FAILED (failures=1, errors=2)
```

And it succeeds with the fixed version of `quant.cu`:
```
...
----------------------------------------------------------------------
Ran 3 tests in 2.207s

OK
```