### PR TITLE
Add Dynamic-precision Quantization to fixed precision

### DIFF
--- a/qtorch/auto_low/auto_low.py
+++ b/qtorch/auto_low/auto_low.py
@@ -186,9 +186,11 @@ def lower(
     backward_number=None,
     forward_rounding="stochastic",
     backward_rounding="stochastic",
+    dynamic_precision=False,
 ):
     quant = Quantizer(
-        forward_number, backward_number, forward_rounding, backward_rounding
+        forward_number, backward_number, forward_rounding, backward_rounding,
+        dynamic_precision,
     )
     lower_func = _get_apply_lower_func(quant, layer_types=layer_types)
     model.apply(lower_func)
@@ -201,11 +203,13 @@ def sequential_lower(
     backward_number=None,
     forward_rounding="stochastic",
     backward_rounding="stochastic",
+    dynamic_precision=False,
 ):
     """Return a new model without touching the old one
     """
     quant = Quantizer(
-        forward_number, backward_number, forward_rounding, backward_rounding
+        forward_number, backward_number, forward_rounding, backward_rounding,
+        dynamic_precision,
     )
 
     lower_func = _get_return_sequential_lower_func(quant, layer_types=layer_types)

--- a/qtorch/number.py
+++ b/qtorch/number.py
@@ -55,7 +55,7 @@ class FixedPoint(Number):
         - :attr: symmetric (bool) : whether to make the representable range symmetric
     """
 
-    def __init__(self, wl, fl, clamp=True, symmetric=False):
+    def __init__(self, wl, fl, clamp=True, symmetric=False, dynamic_precision=False):
         assert wl > 0, "invalid bits for word length: {}".format(wl)
         assert fl > 0, "invalid bits for fractional length: {}".format(fl)
         assert type(symmetric) == bool, "invalid type for clamping choice: {}".format(
@@ -64,10 +64,14 @@ class FixedPoint(Number):
         assert type(symmetric) == bool, "invalid type for symmetric: {}".format(
             type(symmetric)
         )
+        assert type(dynamic_precision) == bool, "invalid type for dynamic precision: {}".format(
+            type(dynamic_precision)
+        )
         self.wl = wl
         self.fl = fl
         self.clamp = clamp
         self.symmetric = symmetric
+        self.dynamic_precision = dynamic_precision
 
     def __str__(self):
         return "FixedPoint (wl={:d}, fl={:d})".format(self.wl, self.fl)

--- a/qtorch/quant/quant_cpu/bit_helper.cpp
+++ b/qtorch/quant/quant_cpu/bit_helper.cpp
@@ -1,19 +1,23 @@
 #include "quant_cpu.h"
 #include "stdio.h"
 
-unsigned int clip_exponent(int exp_bits, int man_bits,
-                           unsigned int old_num,
-                           unsigned int quantized_num)
-{
+unsigned int clip_exponent(int exp_bits, int man_bits, unsigned int old_num,
+                           unsigned int quantized_num) {
   if (quantized_num == 0)
     return quantized_num;
 
-  int quantized_exponent_store = quantized_num << 1 >> 1 >> 23; // 1 sign bit, 23 mantissa bits
-  int max_exponent_store = (1 << (exp_bits - 1)) + 127; // we are not reserving an exponent bit for infinity, nan, etc
+  int quantized_exponent_store =
+      quantized_num << 1 >> 1 >> 23; // 1 sign bit, 23 mantissa bits
+  int max_exponent_store =
+      (1 << (exp_bits - 1)) +
+      127; // we are not reserving an exponent bit for infinity, nan, etc
   // Clippping Value Up
-  if (quantized_exponent_store > max_exponent_store)
-  {
-    unsigned int max_man = (unsigned int)-1 << 9 >> 9 >> (23 - man_bits) << (23 - man_bits); // 1 sign bit, 8 exponent bits, 1 virtual bit
+  if (quantized_exponent_store > max_exponent_store) {
+    unsigned int max_man =
+        (unsigned int)-1 << 9 >>
+        9 >> (23 - man_bits)
+                 << (23 -
+                     man_bits); // 1 sign bit, 8 exponent bits, 1 virtual bit
     unsigned int max_num = ((unsigned int)max_exponent_store << 23) | max_man;
     unsigned int old_sign = old_num >> 31 << 31;
     quantized_num = old_sign | max_num;
@@ -21,14 +25,14 @@ unsigned int clip_exponent(int exp_bits, int man_bits,
   return quantized_num;
 }
 
-unsigned int clip_max_exponent(int man_bits,
-                               unsigned int max_exponent,
-                               unsigned int quantized_num)
-{
-  unsigned int quantized_exponent = quantized_num << 1 >> 24 << 23; // 1 sign bit, 23 mantissa bits
-  if (quantized_exponent > max_exponent)
-  {
-    unsigned int max_man = (unsigned int)-1 << 9 >> 9 >> (23 - man_bits) << (23 - man_bits); // 1 sign bit, 8 exponent bits
+unsigned int clip_max_exponent(int man_bits, unsigned int max_exponent,
+                               unsigned int quantized_num) {
+  unsigned int quantized_exponent =
+      quantized_num << 1 >> 24 << 23; // 1 sign bit, 23 mantissa bits
+  if (quantized_exponent > max_exponent) {
+    unsigned int max_man =
+        (unsigned int)-1 << 9 >> 9 >>
+        (23 - man_bits) << (23 - man_bits); // 1 sign bit, 8 exponent bits
     unsigned int max_num = max_exponent | max_man;
     unsigned int old_sign = quantized_num >> 31 << 31;
     quantized_num = old_sign | max_num;

--- a/qtorch/quant/quant_cpu/quant_cpu.cpp
+++ b/qtorch/quant/quant_cpu/quant_cpu.cpp
@@ -1,40 +1,34 @@
-#include <torch/torch.h>
+#include "quant_cpu.h"
 #include <assert.h>
 #include <random>
+#include <torch/torch.h>
 #include <tuple>
-#include "quant_cpu.h"
-
 
 using namespace at;
 
-enum Mode
-{
-  rNearest,
-  rStochastic
-};
+enum Mode { rNearest, rStochastic };
 
-#define CHECK_CONTIGUOUS(x) TORCH_CHECK(x.is_contiguous(), #x " must be contiguous")
+#define CHECK_CONTIGUOUS(x)                                                    \
+  TORCH_CHECK(x.is_contiguous(), #x " must be contiguous")
 #define CHECK_CPU(x) TORCH_CHECK(!x.is_cuda(), #x " must be a CPU tensor")
-#define CHECK_INPUT(x) \
-  CHECK_CPU(x);        \
+#define CHECK_INPUT(x)                                                         \
+  CHECK_CPU(x);                                                                \
   CHECK_CONTIGUOUS(x);
 
 #define RFLOAT_TO_BITS(x) (*reinterpret_cast<unsigned int *>(x))
 #define RBITS_TO_FLOAT(x) (*reinterpret_cast<float *>(x))
-#define FLOAT_TO_BITS(f, i)     \
-  assert(sizeof f == sizeof i); \
+#define FLOAT_TO_BITS(f, i)                                                    \
+  assert(sizeof f == sizeof i);                                                \
   std::memcpy(&i, &f, sizeof i)
-#define BITS_TO_FLOAT(i, f)     \
-  assert(sizeof f == sizeof i); \
+#define BITS_TO_FLOAT(i, f)                                                    \
+  assert(sizeof f == sizeof i);                                                \
   std::memcpy(&f, &i, sizeof f)
 
 std::random_device rd;
 std::mt19937 gen(rd());
 std::uniform_int_distribution<> dis(0);
 
-template <typename T>
-T clamp_helper(T a, T min, T max)
-{
+template <typename T> T clamp_helper(T a, T min, T max) {
   if (a > max)
     return max;
   else if (a < min)
@@ -43,42 +37,35 @@ T clamp_helper(T a, T min, T max)
     return a;
 }
 
-void printBits(size_t const size, void const * const ptr)
-{
-    unsigned char *b = (unsigned char*) ptr;
-    unsigned char byte;
-    int i, j;
-    
-    for (i = size-1; i >= 0; i--) {
-        for (j = 7; j >= 0; j--) {
+void printBits(size_t const size, void const *const ptr) {
+  unsigned char *b = (unsigned char *)ptr;
+  unsigned char byte;
+  int i, j;
 
-            byte = (b[i] >> j) & 1;
-            printf("%u", byte);
-            if ((i==size-1 && j==7) || (i==size-2 && j==7))
-              printf(" ");
-        }
+  for (i = size - 1; i >= 0; i--) {
+    for (j = 7; j >= 0; j--) {
+
+      byte = (b[i] >> j) & 1;
+      printf("%u", byte);
+      if ((i == size - 1 && j == 7) || (i == size - 2 && j == 7))
+        printf(" ");
     }
+  }
 }
 
-template <typename T>
-T clamp_mask_helper(T a, T min, T max, uint8_t *mask)
-{
-  if (a > max)
-  {
+template <typename T> T clamp_mask_helper(T a, T min, T max, uint8_t *mask) {
+  if (a > max) {
     *mask = 1;
     return max;
-  }
-  else if (a < min)
-  {
+  } else if (a < min) {
     *mask = 1;
     return min;
-  }
-  else
+  } else
     return a;
 }
 
-std::tuple<Tensor, Tensor> fixed_point_quantize_stochastic_mask(Tensor a, int wl, int fl, bool symmetric)
-{
+std::tuple<Tensor, Tensor>
+fixed_point_quantize_stochastic_mask(Tensor a, int wl, int fl, bool symmetric) {
   CHECK_INPUT(a);
   auto r = rand_like(a);
   auto a_array = a.data_ptr<float>();
@@ -91,16 +78,16 @@ std::tuple<Tensor, Tensor> fixed_point_quantize_stochastic_mask(Tensor a, int wl
   int sigma = -fl;
   float t_min, t_max;
   fixed_min_max(wl, fl, symmetric, &t_min, &t_max);
-  for (int64_t i = 0; i < size; i++)
-  {
+  for (int64_t i = 0; i < size; i++) {
     o_array[i] = round(a_array[i], r_array[i], sigma);
-    o_array[i] = clamp_mask_helper<float>(o_array[i], t_min, t_max, m_array + i);
+    o_array[i] =
+        clamp_mask_helper<float>(o_array[i], t_min, t_max, m_array + i);
   }
   return std::make_tuple(o, m);
 }
 
-std::tuple<Tensor, Tensor> fixed_point_quantize_nearest_mask(Tensor a, int wl, int fl, bool symmetric)
-{
+std::tuple<Tensor, Tensor>
+fixed_point_quantize_nearest_mask(Tensor a, int wl, int fl, bool symmetric) {
   CHECK_INPUT(a);
   auto a_array = a.data_ptr<float>();
   auto o = zeros_like(a);
@@ -111,16 +98,16 @@ std::tuple<Tensor, Tensor> fixed_point_quantize_nearest_mask(Tensor a, int wl, i
   int sigma = -fl;
   float t_min, t_max;
   fixed_min_max(wl, fl, symmetric, &t_min, &t_max);
-  for (int64_t i = 0; i < size; i++)
-  {
+  for (int64_t i = 0; i < size; i++) {
     o_array[i] = round(a_array[i], 0.5, sigma);
-    o_array[i] = clamp_mask_helper<float>(o_array[i], t_min, t_max, m_array + i);
+    o_array[i] =
+        clamp_mask_helper<float>(o_array[i], t_min, t_max, m_array + i);
   }
   return std::make_tuple(o, m);
 }
 
-Tensor fixed_point_quantize_stochastic(Tensor a, int wl, int fl, bool clamp, bool symmetric)
-{
+Tensor fixed_point_quantize_stochastic(Tensor a, int wl, int fl, bool clamp,
+                                       bool symmetric) {
   CHECK_INPUT(a);
   auto r = rand_like(a);
   auto a_array = a.data_ptr<float>();
@@ -131,19 +118,17 @@ Tensor fixed_point_quantize_stochastic(Tensor a, int wl, int fl, bool clamp, boo
   int sigma = -fl;
   float t_min, t_max;
   fixed_min_max(wl, fl, symmetric, &t_min, &t_max);
-  for (int64_t i = 0; i < size; i++)
-  {
+  for (int64_t i = 0; i < size; i++) {
     o_array[i] = round(a_array[i], r_array[i], sigma);
-    if (clamp)
-    {
+    if (clamp) {
       o_array[i] = clamp_helper(o_array[i], t_min, t_max);
     }
   }
   return o;
 }
 
-Tensor fixed_point_quantize_nearest(Tensor a, int wl, int fl, bool clamp, bool symmetric)
-{
+Tensor fixed_point_quantize_nearest(Tensor a, int wl, int fl, bool clamp,
+                                    bool symmetric) {
   CHECK_INPUT(a);
   auto a_array = a.data_ptr<float>();
   Tensor o = zeros_like(a);
@@ -152,28 +137,22 @@ Tensor fixed_point_quantize_nearest(Tensor a, int wl, int fl, bool clamp, bool s
   int sigma = -fl;
   float t_min, t_max;
   fixed_min_max(wl, fl, symmetric, &t_min, &t_max);
-  for (int64_t i = 0; i < size; i++)
-  {
+  for (int64_t i = 0; i < size; i++) {
     o_array[i] = round(a_array[i], 0.5, sigma);
-    if (clamp)
-    {
+    if (clamp) {
       o_array[i] = clamp_helper(o_array[i], t_min, t_max);
     }
   }
   return o;
 }
 
-unsigned int round_bitwise(unsigned int target, int man_bits, Mode rounding)
-{
-  
+unsigned int round_bitwise(unsigned int target, int man_bits, Mode rounding) {
+
   unsigned int mask = (1 << (23 - man_bits)) - 1;
   unsigned int rand_prob;
-  if (rounding == rStochastic)
-  {
+  if (rounding == rStochastic) {
     rand_prob = (dis(gen)) & mask;
-  }
-  else
-  {
+  } else {
     rand_prob = 1 << (23 - man_bits - 1);
   }
   unsigned int add_r = target + rand_prob;
@@ -181,11 +160,9 @@ unsigned int round_bitwise(unsigned int target, int man_bits, Mode rounding)
   return quantized;
 }
 
-void block_quantize_helper(float *input, float *output, float *max_elem,
-                           int wl, int size, Mode rounding)
-{
-  for (int64_t i = 0; i < size; i++)
-  {
+void block_quantize_helper(float *input, float *output, float *max_elem, int wl,
+                           int size, Mode rounding) {
+  for (int64_t i = 0; i < size; i++) {
 
     unsigned int max_num;
     FLOAT_TO_BITS(max_elem[i], max_num);
@@ -197,44 +174,45 @@ void block_quantize_helper(float *input, float *output, float *max_elem,
     float target_rebase = input[i] + base_float;
     unsigned int target_bits;
     FLOAT_TO_BITS(target_rebase, target_bits);
-    unsigned int quantized_bits = round_bitwise(target_bits, wl, rounding); // -1 sign, -1 virtual, +2 base
+    unsigned int quantized_bits = round_bitwise(
+        target_bits, wl, rounding); // -1 sign, -1 virtual, +2 base
     float quantized_rebase;
     BITS_TO_FLOAT(quantized_bits, quantized_rebase);
     float quantized = quantized_rebase - base_float;
 
     unsigned int quantize_bits;
     FLOAT_TO_BITS(quantized, quantize_bits);
-    unsigned int clip_quantize = clip_max_exponent(wl - 2, max_exp, quantize_bits);
+    unsigned int clip_quantize =
+        clip_max_exponent(wl - 2, max_exp, quantize_bits);
     BITS_TO_FLOAT(clip_quantize, quantized);
 
     output[i] = quantized;
   }
 }
 
-Tensor get_max_entry(Tensor a, int dim)
-{
+Tensor get_max_entry(Tensor a, int dim) {
   Tensor max_entry;
-  if (dim == -1)
-  {
+  if (dim == -1) {
     max_entry = at::max(at::abs(a)).expand_as(a).contiguous();
-  }
-  else if (dim == 0)
-  {
+  } else if (dim == 0) {
     Tensor input_view = a.view({a.size(0), -1});
-    max_entry = std::get<0>(input_view.abs().max(1, true)).expand_as(input_view).view_as(a).contiguous();
-  }
-  else
-  {
+    max_entry = std::get<0>(input_view.abs().max(1, true))
+                    .expand_as(input_view)
+                    .view_as(a)
+                    .contiguous();
+  } else {
     Tensor input_transpose = a.transpose(0, dim);
-    Tensor input_view = input_transpose.contiguous().view({input_transpose.size(0), -1});
-    Tensor max_transpose = std::get<0>(input_view.abs().max(1, true)).expand_as(input_view).view_as(input_transpose);
+    Tensor input_view =
+        input_transpose.contiguous().view({input_transpose.size(0), -1});
+    Tensor max_transpose = std::get<0>(input_view.abs().max(1, true))
+                               .expand_as(input_view)
+                               .view_as(input_transpose);
     max_entry = max_transpose.transpose(dim, 0).contiguous();
   }
   return max_entry;
 }
 
-Tensor block_quantize_nearest(Tensor a, int wl, int dim)
-{
+Tensor block_quantize_nearest(Tensor a, int wl, int dim) {
   CHECK_INPUT(a);
   auto a_array = a.data_ptr<float>();
   Tensor o = zeros_like(a);
@@ -248,8 +226,7 @@ Tensor block_quantize_nearest(Tensor a, int wl, int dim)
   return o;
 }
 
-Tensor block_quantize_stochastic(Tensor a, int wl, int dim)
-{
+Tensor block_quantize_stochastic(Tensor a, int wl, int dim) {
   CHECK_INPUT(a);
   auto a_array = a.data_ptr<float>();
   Tensor o = zeros_like(a);
@@ -264,32 +241,30 @@ Tensor block_quantize_stochastic(Tensor a, int wl, int dim)
   return o;
 }
 
-Tensor float_quantize(Tensor a, int man_bits, int exp_bits, Mode rounding){
+Tensor float_quantize(Tensor a, int man_bits, int exp_bits, Mode rounding) {
   auto a_array = a.data_ptr<float>();
   auto o = zeros_like(a);
   auto o_array = o.data_ptr<float>();
   int size = a.numel();
 
-  for (int64_t i = 0; i < size; i++)
-  {
-    unsigned int target,quantize_bits;
+  for (int64_t i = 0; i < size; i++) {
+    unsigned int target, quantize_bits;
     FLOAT_TO_BITS(a_array[i], target);
     float quantized;
 
-    int target_exp = (target << 1 >> 1 >> 23) -127; 
+    int target_exp = (target << 1 >> 1 >> 23) - 127;
     int min_exp = -((1 << (exp_bits - 1)) - 2);
     bool subnormal = (target_exp < min_exp);
-    if (subnormal){
-      float shift_float,val;
-      int shift_bits = ((127+min_exp)<<23) | (target >> 31 <<31);
+    if (subnormal) {
+      float shift_float, val;
+      int shift_bits = ((127 + min_exp) << 23) | (target >> 31 << 31);
       BITS_TO_FLOAT(shift_bits, shift_float);
-      val=a_array[i]+shift_float;
+      val = a_array[i] + shift_float;
       FLOAT_TO_BITS(val, target);
       quantize_bits = round_bitwise(target, man_bits, rounding);
       BITS_TO_FLOAT(quantize_bits, quantized);
-      quantized=quantized-shift_float;
-    }
-    else{
+      quantized = quantized - shift_float;
+    } else {
       quantize_bits = round_bitwise(target, man_bits, rounding);
       quantize_bits = clip_exponent(exp_bits, man_bits, target, quantize_bits);
       BITS_TO_FLOAT(quantize_bits, quantized);
@@ -299,24 +274,31 @@ Tensor float_quantize(Tensor a, int man_bits, int exp_bits, Mode rounding){
   return o;
 }
 
-Tensor float_quantize_stochastic(Tensor a, int man_bits, int exp_bits)
-{
-  return float_quantize(a,man_bits, exp_bits, rStochastic);
+Tensor float_quantize_stochastic(Tensor a, int man_bits, int exp_bits) {
+  return float_quantize(a, man_bits, exp_bits, rStochastic);
 }
 
-Tensor float_quantize_nearest(Tensor a, int man_bits, int exp_bits)
-{
-  return float_quantize(a,man_bits, exp_bits, rNearest);
+Tensor float_quantize_nearest(Tensor a, int man_bits, int exp_bits) {
+  return float_quantize(a, man_bits, exp_bits, rNearest);
 }
 
-PYBIND11_MODULE(TORCH_EXTENSION_NAME, m)
-{
-  m.def("fixed_point_quantize_stochastic_mask", &fixed_point_quantize_stochastic_mask, "Fixed Point Number Stochastic Quantization with Mask (CPU)");
-  m.def("fixed_point_quantize_stochastic", &fixed_point_quantize_stochastic, "Fixed Point Number Stochastic Quantization (CPU)");
-  m.def("block_quantize_stochastic", &block_quantize_stochastic, "Block Floating Point Number Stochastic Quantization (CPU)");
-  m.def("float_quantize_stochastic", &float_quantize_stochastic, "Low-Bitwidth Floating Point Number Stochastic Quantization (CUDA)");
-  m.def("fixed_point_quantize_nearest_mask", &fixed_point_quantize_nearest_mask, "Fixed Point Number Nearest Quantization with Mask (CPU)");
-  m.def("fixed_point_quantize_nearest", &fixed_point_quantize_nearest, "Fixed Point Number Nearest Neighbor Quantization (CPU)");
-  m.def("block_quantize_nearest", &block_quantize_nearest, "Block Floating Point Number Nearest Neighbor Quantization (CPU)");
-  m.def("float_quantize_nearest", &float_quantize_nearest, "Low-Bitwidth Floating Point Number Nearest Neighbor Quantization (CPU)");
+PYBIND11_MODULE(TORCH_EXTENSION_NAME, m) {
+  m.def("fixed_point_quantize_stochastic_mask",
+        &fixed_point_quantize_stochastic_mask,
+        "Fixed Point Number Stochastic Quantization with Mask (CPU)");
+  m.def("fixed_point_quantize_stochastic", &fixed_point_quantize_stochastic,
+        "Fixed Point Number Stochastic Quantization (CPU)");
+  m.def("block_quantize_stochastic", &block_quantize_stochastic,
+        "Block Floating Point Number Stochastic Quantization (CPU)");
+  m.def("float_quantize_stochastic", &float_quantize_stochastic,
+        "Low-Bitwidth Floating Point Number Stochastic Quantization (CUDA)");
+  m.def("fixed_point_quantize_nearest_mask", &fixed_point_quantize_nearest_mask,
+        "Fixed Point Number Nearest Quantization with Mask (CPU)");
+  m.def("fixed_point_quantize_nearest", &fixed_point_quantize_nearest,
+        "Fixed Point Number Nearest Neighbor Quantization (CPU)");
+  m.def("block_quantize_nearest", &block_quantize_nearest,
+        "Block Floating Point Number Nearest Neighbor Quantization (CPU)");
+  m.def(
+      "float_quantize_nearest", &float_quantize_nearest,
+      "Low-Bitwidth Floating Point Number Nearest Neighbor Quantization (CPU)");
 }

--- a/qtorch/quant/quant_cpu/quant_cpu.h
+++ b/qtorch/quant/quant_cpu/quant_cpu.h
@@ -3,15 +3,12 @@
 unsigned int clip_exponent(int exp_bits, int man_bits, unsigned int old_num,
                            unsigned int quantized_num);
 
-unsigned int clip_max_exponent(int man_bits,
-                               unsigned int max_exponent,
+unsigned int clip_max_exponent(int man_bits, unsigned int max_exponent,
                                unsigned int quantized_num);
 
-template <typename T>
-T clamp_helper(T a, T min, T max);
+template <typename T> T clamp_helper(T a, T min, T max);
 
-template <typename T>
-T clamp_mask_helper(T a, T min, T max, uint8_t *mask);
+template <typename T> T clamp_mask_helper(T a, T min, T max, uint8_t *mask);
 
 void fixed_min_max(int wl, int fl, bool symmetric, float *t_min, float *t_max);
 

--- a/qtorch/quant/quant_cpu/sim_helper.cpp
+++ b/qtorch/quant/quant_cpu/sim_helper.cpp
@@ -2,8 +2,7 @@
 #include <math.h>
 #include <stdint.h>
 
-void fixed_min_max(int wl, int fl, bool symmetric, float *t_min, float *t_max)
-{
+void fixed_min_max(int wl, int fl, bool symmetric, float *t_min, float *t_max) {
   int sigma = -fl;
   *t_min = -ldexp(1.0, wl - fl - 1);
   *t_max = -*t_min - ldexp(1.0, sigma);
@@ -11,8 +10,7 @@ void fixed_min_max(int wl, int fl, bool symmetric, float *t_min, float *t_max)
     *t_min = *t_min + ldexp(1.0, sigma);
 }
 
-float round(float a, float r, int sigma)
-{
+float round(float a, float r, int sigma) {
   a = ldexp(a, -sigma);
   a = nearbyint(a + r - 0.5);
   // a = floor(a + r);

--- a/qtorch/quant/quant_cuda/bit_helper.cu
+++ b/qtorch/quant/quant_cuda/bit_helper.cu
@@ -1,42 +1,48 @@
-#define FLOAT_TO_BITS(x) (*reinterpret_cast<unsigned int*>(x))
-#define BITS_TO_FLOAT(x) (*reinterpret_cast<float*>(x))
+#define FLOAT_TO_BITS(x) (*reinterpret_cast<unsigned int *>(x))
+#define BITS_TO_FLOAT(x) (*reinterpret_cast<float *>(x))
 
 __device__ __forceinline__ unsigned int extract_exponent(float *a) {
-  unsigned int temp = *(reinterpret_cast<unsigned int*>(a));
+  unsigned int temp = *(reinterpret_cast<unsigned int *>(a));
   temp = (temp << 1 >> 24); // single preciision, 1 sign bit, 23 mantissa bits
-  return temp-127+1; // exponent offset and virtual bit
+  return temp - 127 + 1;    // exponent offset and virtual bit
 }
 
-__device__ __forceinline__ unsigned int round_bitwise_stochastic(unsigned int target,
-                                                                 unsigned int rand_prob,
-                                                                 int man_bits) {
-    unsigned int mask = (1 << (23-man_bits)) - 1;
-    unsigned int add_r = target+(rand_prob & mask);
-    unsigned int quantized = add_r & ~mask;
-    return quantized;
+__device__ __forceinline__ unsigned int
+round_bitwise_stochastic(unsigned int target, unsigned int rand_prob,
+                         int man_bits) {
+  unsigned int mask = (1 << (23 - man_bits)) - 1;
+  unsigned int add_r = target + (rand_prob & mask);
+  unsigned int quantized = add_r & ~mask;
+  return quantized;
 }
 
-__device__ __forceinline__ unsigned int round_bitwise_nearest(unsigned int target,
-                                                              int man_bits) {
-    unsigned int mask = (1 << (23-man_bits)) - 1;
-    unsigned int rand_prob = 1 << (23-man_bits-1);
-    unsigned int add_r = target+rand_prob;
-    unsigned int quantized = add_r & ~mask;
-    return quantized;
+__device__ __forceinline__ unsigned int
+round_bitwise_nearest(unsigned int target, int man_bits) {
+  unsigned int mask = (1 << (23 - man_bits)) - 1;
+  unsigned int rand_prob = 1 << (23 - man_bits - 1);
+  unsigned int add_r = target + rand_prob;
+  unsigned int quantized = add_r & ~mask;
+  return quantized;
 }
 
-__device__ __forceinline__ unsigned int clip_exponent(int exp_bits, int man_bits,
-                                                      unsigned int old_num,
-                                                      unsigned int quantized_num) {
+__device__ __forceinline__ unsigned int
+clip_exponent(int exp_bits, int man_bits, unsigned int old_num,
+              unsigned int quantized_num) {
   if (quantized_num == 0)
     return quantized_num;
 
-  int quantized_exponent_store = quantized_num << 1 >> 1 >> 23; // 1 sign bit, 23 mantissa bits
-  int max_exponent_store = (1 << (exp_bits - 1)) + 127; // we are not reserving an exponent bit for infinity, nan, etc
+  int quantized_exponent_store =
+      quantized_num << 1 >> 1 >> 23; // 1 sign bit, 23 mantissa bits
+  int max_exponent_store =
+      (1 << (exp_bits - 1)) +
+      127; // we are not reserving an exponent bit for infinity, nan, etc
   // Clippping Value Up
-  if (quantized_exponent_store > max_exponent_store)
-  {
-    unsigned int max_man = (unsigned int)-1 << 9 >> 9 >> (23 - man_bits) << (23 - man_bits); // 1 sign bit, 8 exponent bits, 1 virtual bit
+  if (quantized_exponent_store > max_exponent_store) {
+    unsigned int max_man =
+        (unsigned int)-1 << 9 >>
+        9 >> (23 - man_bits)
+                 << (23 -
+                     man_bits); // 1 sign bit, 8 exponent bits, 1 virtual bit
     unsigned int max_num = ((unsigned int)max_exponent_store << 23) | max_man;
     unsigned int old_sign = old_num >> 31 << 31;
     quantized_num = old_sign | max_num;
@@ -44,13 +50,15 @@ __device__ __forceinline__ unsigned int clip_exponent(int exp_bits, int man_bits
   return quantized_num;
 }
 
-
-__device__ __forceinline__ unsigned int clip_max_exponent(int man_bits,
-                                                          unsigned int max_exponent,
-                                                          unsigned int quantized_num) {
-  unsigned int quantized_exponent = quantized_num << 1 >> 24 << 23; // 1 sign bit, 23 mantissa bits
+__device__ __forceinline__ unsigned int
+clip_max_exponent(int man_bits, unsigned int max_exponent,
+                  unsigned int quantized_num) {
+  unsigned int quantized_exponent =
+      quantized_num << 1 >> 24 << 23; // 1 sign bit, 23 mantissa bits
   if (quantized_exponent > max_exponent) {
-    unsigned int max_man = (unsigned int ) -1 << 9 >> 9 >> (23-man_bits) << (23-man_bits); // 1 sign bit, 8 exponent bits
+    unsigned int max_man =
+        (unsigned int)-1 << 9 >> 9 >>
+        (23 - man_bits) << (23 - man_bits); // 1 sign bit, 8 exponent bits
     unsigned int max_num = max_exponent | max_man;
     unsigned int old_sign = quantized_num >> 31 << 31;
     quantized_num = old_sign | max_num;

--- a/qtorch/quant/quant_cuda/block_kernel.cu
+++ b/qtorch/quant/quant_cuda/block_kernel.cu
@@ -1,28 +1,29 @@
+#include "bit_helper.cu"
 #include "quant_kernel.h"
 #include "sim_helper.cu"
-#include "bit_helper.cu"
 
 // quantize a float into a floating point with [exp_bits] exponent and
 // [man_bits] mantissa
-__global__ void block_kernel_stochastic(float* __restrict__ a,
-                                        int* __restrict__ r,
-                                        float* o, int size,
-                                        float* __restrict__ max_entry,
+__global__ void block_kernel_stochastic(float *__restrict__ a,
+                                        int *__restrict__ r, float *o, int size,
+                                        float *__restrict__ max_entry,
                                         int man_bits) {
   int index = blockIdx.x * blockDim.x + threadIdx.x;
   if (index < size) {
     unsigned int max_entry_bits = FLOAT_TO_BITS(&max_entry[index]);
     unsigned int max_exp = max_entry_bits << 1 >> 24 << 23;
-    float base_float = 6*BITS_TO_FLOAT(&max_exp);
+    float base_float = 6 * BITS_TO_FLOAT(&max_exp);
 
-    float target_rebase = a[index]+base_float;
+    float target_rebase = a[index] + base_float;
     unsigned int target_bits = FLOAT_TO_BITS(&target_rebase);
-    unsigned int rand_prob = (unsigned int) r[index];
-    unsigned int quantized = round_bitwise_stochastic(target_bits, rand_prob, man_bits);
-    float quantize_float = BITS_TO_FLOAT(&quantized)-base_float;
+    unsigned int rand_prob = (unsigned int)r[index];
+    unsigned int quantized =
+        round_bitwise_stochastic(target_bits, rand_prob, man_bits);
+    float quantize_float = BITS_TO_FLOAT(&quantized) - base_float;
 
-    unsigned int quantize_bits = FLOAT_TO_BITS(&quantize_float) ;
-    unsigned int clip_quantize = clip_max_exponent(man_bits-2, max_exp, quantize_bits);
+    unsigned int quantize_bits = FLOAT_TO_BITS(&quantize_float);
+    unsigned int clip_quantize =
+        clip_max_exponent(man_bits - 2, max_exp, quantize_bits);
     quantize_float = BITS_TO_FLOAT(&clip_quantize);
     o[index] = quantize_float;
   }
@@ -30,23 +31,23 @@ __global__ void block_kernel_stochastic(float* __restrict__ a,
 
 // quantize a float into a floating point with [exp_bits] exponent and
 // [man_bits] mantissa
-__global__ void block_kernel_nearest(float* __restrict__ a,
-                                     float* o, int size,
-                                     float* __restrict__ max_entry,
+__global__ void block_kernel_nearest(float *__restrict__ a, float *o, int size,
+                                     float *__restrict__ max_entry,
                                      int man_bits) {
   int index = blockIdx.x * blockDim.x + threadIdx.x;
   if (index < size) {
     unsigned int max_entry_bits = FLOAT_TO_BITS(&max_entry[index]);
     unsigned int max_exp = max_entry_bits << 1 >> 24 << 23;
-    float base_float = 6*BITS_TO_FLOAT(&max_exp);
+    float base_float = 6 * BITS_TO_FLOAT(&max_exp);
 
-    float target_rebase = a[index]+base_float;
+    float target_rebase = a[index] + base_float;
     unsigned int target_bits = FLOAT_TO_BITS(&target_rebase);
     unsigned int quantized = round_bitwise_nearest(target_bits, man_bits);
-    float quantize_float = BITS_TO_FLOAT(&quantized)-base_float;
+    float quantize_float = BITS_TO_FLOAT(&quantized) - base_float;
 
-    unsigned int quantize_bits = FLOAT_TO_BITS(&quantize_float); 
-    unsigned int clip_quantize = clip_max_exponent(man_bits-2, max_exp, quantize_bits); // sign bit, virtual bit
+    unsigned int quantize_bits = FLOAT_TO_BITS(&quantize_float);
+    unsigned int clip_quantize = clip_max_exponent(
+        man_bits - 2, max_exp, quantize_bits); // sign bit, virtual bit
     quantize_float = BITS_TO_FLOAT(&clip_quantize);
 
     o[index] = quantize_float;
@@ -55,29 +56,26 @@ __global__ void block_kernel_nearest(float* __restrict__ a,
 
 // quantize a float into a floating point with [exp_bits] exponent and
 // [man_bits] mantissa
-__global__ void block_kernel_sim_stochastic(float* __restrict__ a,
-                                            float* __restrict__ r,
-                                            float* o, int size,
-                                            float* max_entry,
+__global__ void block_kernel_sim_stochastic(float *__restrict__ a,
+                                            float *__restrict__ r, float *o,
+                                            int size, float *max_entry,
                                             int wl) {
   int index = blockIdx.x * blockDim.x + threadIdx.x;
   if (index < size) {
-    int exponent = ((int) extract_exponent(max_entry));
-    int sigma = exponent-(wl-1);
+    int exponent = ((int)extract_exponent(max_entry));
+    int sigma = exponent - (wl - 1);
     o[index] = round(a[index], r[index], sigma);
   }
 }
 
 // quantize a float into a floating point with [exp_bits] exponent and
 // [man_bits] mantissa
-__global__ void block_kernel_sim_nearest(float* __restrict__ a,
-                                         float* o, int size,
-                                         float* max_entry,
-                                         int wl) {
+__global__ void block_kernel_sim_nearest(float *__restrict__ a, float *o,
+                                         int size, float *max_entry, int wl) {
   int index = blockIdx.x * blockDim.x + threadIdx.x;
   if (index < size) {
-    int exponent = ((int) extract_exponent(max_entry));
-    int sigma = exponent-(wl-1);
+    int exponent = ((int)extract_exponent(max_entry));
+    int sigma = exponent - (wl - 1);
     o[index] = nearest_round(a[index], sigma);
   }
 }

--- a/qtorch/quant/quant_cuda/fixed_point_kernel.cu
+++ b/qtorch/quant/quant_cuda/fixed_point_kernel.cu
@@ -1,16 +1,19 @@
 #include "quant_kernel.h"
 #include "sim_helper.cu"
 
-
 template <typename T>
 __device__ __forceinline__ T clamp_helper(T a, T min, T max) {
-  if (a > max) return max;
-  else if (a < min) return min;
-  else return a;
+  if (a > max)
+    return max;
+  else if (a < min)
+    return min;
+  else
+    return a;
 }
 
 template <typename T>
-__device__ __forceinline__ T clamp_mask_helper(T a, T min, T max, uint8_t* mask) {
+__device__ __forceinline__ T clamp_mask_helper(T a, T min, T max,
+                                               uint8_t *mask) {
   if (a > max) {
     *mask = 1;
     return max;
@@ -22,13 +25,12 @@ __device__ __forceinline__ T clamp_mask_helper(T a, T min, T max, uint8_t* mask)
   return a;
 }
 
-// quantize an array of real numbers into fixed point with word length [wl] and [fl] fractional bits
-// 2**-[sigma] is the smallest unit of the fixed point representation. Stochastic Rounding with r.
-__global__ void fixed_point_quantize_kernel_stochastic(float* __restrict__ a,
-                                                       float* __restrict__ r,
-                                                       float* o, int size,
-                                                       int sigma, bool use_clamp,
-                                                       float t_min, float t_max) {
+// quantize an array of real numbers into fixed point with word length [wl] and
+// [fl] fractional bits 2**-[sigma] is the smallest unit of the fixed point
+// representation. Stochastic Rounding with r.
+__global__ void fixed_point_quantize_kernel_stochastic(
+    float *__restrict__ a, float *__restrict__ r, float *o, int size, int sigma,
+    bool use_clamp, float t_min, float t_max) {
   int index = blockIdx.x * blockDim.x + threadIdx.x;
   if (index < size) {
     o[index] = round(a[index], r[index], sigma);
@@ -38,10 +40,11 @@ __global__ void fixed_point_quantize_kernel_stochastic(float* __restrict__ a,
   }
 }
 
-// quantize an array of real numbers into fixed point with word length [wl] and [fl] fractional bits
-// 2**-[sigma] is the smallest unit of the fixed point representation. Nearest Neighbor Rounding.
-__global__ void fixed_point_quantize_kernel_nearest(float* __restrict__ a,
-                                                    float* o, int size,
+// quantize an array of real numbers into fixed point with word length [wl] and
+// [fl] fractional bits 2**-[sigma] is the smallest unit of the fixed point
+// representation. Nearest Neighbor Rounding.
+__global__ void fixed_point_quantize_kernel_nearest(float *__restrict__ a,
+                                                    float *o, int size,
                                                     int sigma, bool use_clamp,
                                                     float t_min, float t_max) {
   int index = blockIdx.x * blockDim.x + threadIdx.x;
@@ -53,25 +56,24 @@ __global__ void fixed_point_quantize_kernel_nearest(float* __restrict__ a,
   }
 }
 
-__global__ void fixed_point_quantize_kernel_mask_stochastic(float* __restrict__ a,
-                                                            float* __restrict__ r,
-                                                            float* o, uint8_t* m,
-                                                            int size, int sigma,
-                                                            float t_min, float t_max) {
+__global__ void fixed_point_quantize_kernel_mask_stochastic(
+    float *__restrict__ a, float *__restrict__ r, float *o, uint8_t *m,
+    int size, int sigma, float t_min, float t_max) {
   int index = blockIdx.x * blockDim.x + threadIdx.x;
   if (index < size) {
     o[index] = round(a[index], r[index], sigma);
-    o[index] = clamp_mask_helper(o[index], t_min, t_max, m+index);
+    o[index] = clamp_mask_helper(o[index], t_min, t_max, m + index);
   }
 }
 
-__global__ void fixed_point_quantize_kernel_mask_nearest(float* __restrict__ a,
-                                                         float* o, uint8_t* m,
+__global__ void fixed_point_quantize_kernel_mask_nearest(float *__restrict__ a,
+                                                         float *o, uint8_t *m,
                                                          int size, int sigma,
-                                                         float t_min, float t_max) {
+                                                         float t_min,
+                                                         float t_max) {
   int index = blockIdx.x * blockDim.x + threadIdx.x;
   if (index < size) {
     o[index] = nearest_round(a[index], sigma);
-    o[index] = clamp_mask_helper(o[index], t_min, t_max, m+index);
+    o[index] = clamp_mask_helper(o[index], t_min, t_max, m + index);
   }
 }

--- a/qtorch/quant/quant_cuda/float_kernel.cu
+++ b/qtorch/quant/quant_cuda/float_kernel.cu
@@ -1,33 +1,30 @@
-#include "quant_kernel.h"
 #include "bit_helper.cu"
+#include "quant_kernel.h"
 
 // quantize a float into a floating point with [exp_bits] exponent and
 // [man_bits] mantissa
-__global__ void float_kernel_stochastic(float* __restrict__ a,
-                                        int* __restrict__ r,
-                                        float* o, int size,
-                                        int man_bits,
-                                        int exp_bits) {
+__global__ void float_kernel_stochastic(float *__restrict__ a,
+                                        int *__restrict__ r, float *o, int size,
+                                        int man_bits, int exp_bits) {
   int index = blockIdx.x * blockDim.x + threadIdx.x;
   if (index < size) {
-    unsigned int rand_prob = (unsigned int) r[index];
-    unsigned int target,quantize_bits;
+    unsigned int rand_prob = (unsigned int)r[index];
+    unsigned int target, quantize_bits;
     target = FLOAT_TO_BITS(&a[index]);
     float quantized;
 
-    int target_exp = (target << 1 >> 1 >> 23) -127; 
+    int target_exp = (target << 1 >> 1 >> 23) - 127;
     int min_exp = -((1 << (exp_bits - 1)) - 2);
     bool subnormal = (target_exp < min_exp);
-    if (subnormal){
-      float shift_float,val;
-      int shift_bits = ((127+min_exp)<<23) | (target >> 31 <<31);
+    if (subnormal) {
+      float shift_float, val;
+      int shift_bits = ((127 + min_exp) << 23) | (target >> 31 << 31);
       shift_float = BITS_TO_FLOAT(&shift_bits);
-      val=a[index]+shift_float;
+      val = a[index] + shift_float;
       target = FLOAT_TO_BITS(&val);
       quantize_bits = round_bitwise_stochastic(target, rand_prob, man_bits);
       quantized = BITS_TO_FLOAT(&quantize_bits) - shift_float;
-    }
-    else{
+    } else {
       quantize_bits = round_bitwise_stochastic(target, rand_prob, man_bits);
       quantize_bits = clip_exponent(exp_bits, man_bits, target, quantize_bits);
       quantized = BITS_TO_FLOAT(&quantize_bits);
@@ -38,29 +35,26 @@ __global__ void float_kernel_stochastic(float* __restrict__ a,
 
 // quantize a float into a floating point with [exp_bits] exponent and
 // [man_bits] mantissa
-__global__ void float_kernel_nearest(float* __restrict__ a,
-                                     float* o, int size,
-                                     int man_bits,
-                                     int exp_bits) {
+__global__ void float_kernel_nearest(float *__restrict__ a, float *o, int size,
+                                     int man_bits, int exp_bits) {
   int index = blockIdx.x * blockDim.x + threadIdx.x;
   if (index < size) {
-    unsigned int target,quantize_bits;
+    unsigned int target, quantize_bits;
     target = FLOAT_TO_BITS(&a[index]);
     float quantized;
 
-    int target_exp = (target << 1 >> 1 >> 23) -127; 
+    int target_exp = (target << 1 >> 1 >> 23) - 127;
     int min_exp = -((1 << (exp_bits - 1)) - 2);
     bool subnormal = (target_exp < min_exp);
-    if (subnormal){
-      float shift_float,val;
-      int shift_bits = ((127+min_exp)<<23) | (target >> 31 <<31);
+    if (subnormal) {
+      float shift_float, val;
+      int shift_bits = ((127 + min_exp) << 23) | (target >> 31 << 31);
       shift_float = BITS_TO_FLOAT(&shift_bits);
-      val=a[index]+shift_float;
+      val = a[index] + shift_float;
       target = FLOAT_TO_BITS(&val);
       quantize_bits = round_bitwise_nearest(target, man_bits);
       quantized = BITS_TO_FLOAT(&quantize_bits) - shift_float;
-    }
-    else{
+    } else {
       quantize_bits = round_bitwise_nearest(target, man_bits);
       quantize_bits = clip_exponent(exp_bits, man_bits, target, quantize_bits);
       quantized = BITS_TO_FLOAT(&quantize_bits);

--- a/qtorch/quant/quant_cuda/quant_cuda.cpp
+++ b/qtorch/quant/quant_cuda/quant_cuda.cpp
@@ -12,15 +12,18 @@ using namespace at;
   CHECK_CONTIGUOUS(x)
 
 Tensor fixed_point_quantize_nearest(Tensor a, int wl, int fl, bool use_clamp,
-                                    bool symmetric) {
+                                    bool symmetric, bool dynamic_precision) {
   CHECK_INPUT(a);
-  return fixed_point_quantize_nearest_cuda(a, wl, fl, use_clamp, symmetric);
+  return fixed_point_quantize_nearest_cuda(a, wl, fl, use_clamp, symmetric,
+                                           dynamic_precision);
 }
 
 std::tuple<Tensor, Tensor>
-fixed_point_quantize_nearest_mask(Tensor a, int wl, int fl, bool symmetric) {
+fixed_point_quantize_nearest_mask(Tensor a, int wl, int fl, bool symmetric,
+                                  bool dynamic_precision) {
   CHECK_INPUT(a);
-  return fixed_point_quantize_nearest_mask_cuda(a, wl, fl, symmetric);
+  return fixed_point_quantize_nearest_mask_cuda(a, wl, fl, symmetric,
+                                                dynamic_precision);
 }
 
 Tensor block_quantize_nearest(Tensor a, int wl, int dim) {
@@ -39,15 +42,18 @@ Tensor float_quantize_nearest(Tensor a, int man_bits, int exp_bits) {
 }
 
 Tensor fixed_point_quantize_stochastic(Tensor a, int wl, int fl, bool use_clamp,
-                                       bool symmetric) {
+                                       bool symmetric, bool dynamic_precision) {
   CHECK_INPUT(a);
-  return fixed_point_quantize_stochastic_cuda(a, wl, fl, use_clamp, symmetric);
+  return fixed_point_quantize_stochastic_cuda(a, wl, fl, use_clamp, symmetric,
+                                              dynamic_precision);
 }
 
 std::tuple<Tensor, Tensor>
-fixed_point_quantize_stochastic_mask(Tensor a, int wl, int fl, bool symmetric) {
+fixed_point_quantize_stochastic_mask(Tensor a, int wl, int fl, bool symmetric,
+                                     bool dynamic_precision) {
   CHECK_INPUT(a);
-  return fixed_point_quantize_stochastic_mask_cuda(a, wl, fl, symmetric);
+  return fixed_point_quantize_stochastic_mask_cuda(a, wl, fl, symmetric,
+                                                   dynamic_precision);
 }
 
 Tensor block_quantize_stochastic(Tensor a, int wl, int dim) {

--- a/qtorch/quant/quant_cuda/quant_cuda.cpp
+++ b/qtorch/quant/quant_cuda/quant_cuda.cpp
@@ -1,87 +1,91 @@
-#include <torch/torch.h>
 #include "quant_cuda.h"
+#include <torch/torch.h>
 #include <tuple>
 
 using namespace at;
 
 #define CHECK_CUDA(x) TORCH_CHECK(x.is_cuda(), #x " must be a CUDA tensor")
-#define CHECK_CONTIGUOUS(x) TORCH_CHECK(x.is_contiguous(), #x " must be contiguous")
-#define CHECK_INPUT(x) \
-  CHECK_CUDA(x);       \
+#define CHECK_CONTIGUOUS(x)                                                    \
+  TORCH_CHECK(x.is_contiguous(), #x " must be contiguous")
+#define CHECK_INPUT(x)                                                         \
+  CHECK_CUDA(x);                                                               \
   CHECK_CONTIGUOUS(x)
 
-Tensor fixed_point_quantize_nearest(Tensor a, int wl, int fl, bool use_clamp, bool symmetric)
-{
+Tensor fixed_point_quantize_nearest(Tensor a, int wl, int fl, bool use_clamp,
+                                    bool symmetric) {
   CHECK_INPUT(a);
   return fixed_point_quantize_nearest_cuda(a, wl, fl, use_clamp, symmetric);
 }
 
-std::tuple<Tensor, Tensor> fixed_point_quantize_nearest_mask(Tensor a, int wl, int fl,
-                                                             bool symmetric)
-{
+std::tuple<Tensor, Tensor>
+fixed_point_quantize_nearest_mask(Tensor a, int wl, int fl, bool symmetric) {
   CHECK_INPUT(a);
   return fixed_point_quantize_nearest_mask_cuda(a, wl, fl, symmetric);
 }
 
-Tensor block_quantize_nearest(Tensor a, int wl, int dim)
-{
+Tensor block_quantize_nearest(Tensor a, int wl, int dim) {
   CHECK_INPUT(a);
   return block_quantize_nearest_cuda(a, wl, dim);
 }
 
-Tensor block_quantize_sim_nearest(Tensor a, int wl)
-{
+Tensor block_quantize_sim_nearest(Tensor a, int wl) {
   CHECK_INPUT(a);
   return block_quantize_sim_nearest_cuda(a, wl);
 }
 
-Tensor float_quantize_nearest(Tensor a, int man_bits, int exp_bits)
-{
+Tensor float_quantize_nearest(Tensor a, int man_bits, int exp_bits) {
   CHECK_INPUT(a);
   return float_quantize_nearest_cuda(a, man_bits, exp_bits);
 }
 
-Tensor fixed_point_quantize_stochastic(Tensor a, int wl, int fl, bool use_clamp, bool symmetric)
-{
+Tensor fixed_point_quantize_stochastic(Tensor a, int wl, int fl, bool use_clamp,
+                                       bool symmetric) {
   CHECK_INPUT(a);
   return fixed_point_quantize_stochastic_cuda(a, wl, fl, use_clamp, symmetric);
 }
 
-std::tuple<Tensor, Tensor> fixed_point_quantize_stochastic_mask(Tensor a, int wl, int fl,
-                                                                bool symmetric)
-{
+std::tuple<Tensor, Tensor>
+fixed_point_quantize_stochastic_mask(Tensor a, int wl, int fl, bool symmetric) {
   CHECK_INPUT(a);
   return fixed_point_quantize_stochastic_mask_cuda(a, wl, fl, symmetric);
 }
 
-Tensor block_quantize_stochastic(Tensor a, int wl, int dim)
-{
+Tensor block_quantize_stochastic(Tensor a, int wl, int dim) {
   CHECK_INPUT(a);
   return block_quantize_stochastic_cuda(a, wl, dim);
 }
 
-Tensor block_quantize_sim_stochastic(Tensor a, int wl)
-{
+Tensor block_quantize_sim_stochastic(Tensor a, int wl) {
   CHECK_INPUT(a);
   return block_quantize_sim_stochastic_cuda(a, wl);
 }
 
-Tensor float_quantize_stochastic(Tensor a, int man_bits, int exp_bits)
-{
+Tensor float_quantize_stochastic(Tensor a, int man_bits, int exp_bits) {
   CHECK_INPUT(a);
   return float_quantize_stochastic_cuda(a, man_bits, exp_bits);
 }
 
-PYBIND11_MODULE(TORCH_EXTENSION_NAME, m)
-{
-  m.def("fixed_point_quantize_stochastic", &fixed_point_quantize_stochastic, "Fixed Point Number Stochastic Quantization (CUDA)");
-  m.def("fixed_point_quantize_stochastic_mask", &fixed_point_quantize_stochastic_mask, "Fixed Point Number Stochastic Quantization (CUDA)");
-  m.def("block_quantize_stochastic", &block_quantize_stochastic, "Block Floating Point Number Stochastic Quantization (CUDA)");
-  m.def("block_quantize_sim_stochastic", &block_quantize_sim_stochastic, "Block Floating Point Number Stochastic Quantization (CUDA)");
-  m.def("float_quantize_stochastic", &float_quantize_stochastic, "Low-Bitwidth Floating Point Number Stochastic Quantization (CUDA)");
-  m.def("fixed_point_quantize_nearest", &fixed_point_quantize_nearest, "Fixed Point Number Nearest Neighbor Quantization (CUDA)");
-  m.def("fixed_point_quantize_nearest_mask", &fixed_point_quantize_nearest_mask, "Fixed Point Number Nearest Neighbor Quantization (CUDA)");
-  m.def("block_quantize_nearest", &block_quantize_nearest, "Block Floating Point Number Nearest Neighbor Quantization (CUDA)");
-  m.def("block_quantize_sim_nearest", &block_quantize_sim_nearest, "Block Floating Point Number Stochastic Quantization (CUDA)");
-  m.def("float_quantize_nearest", &float_quantize_nearest, "Low-Bitwidth Floating Point Number Nearest Neighbor Quantization (CUDA)");
+PYBIND11_MODULE(TORCH_EXTENSION_NAME, m) {
+  m.def("fixed_point_quantize_stochastic", &fixed_point_quantize_stochastic,
+        "Fixed Point Number Stochastic Quantization (CUDA)");
+  m.def("fixed_point_quantize_stochastic_mask",
+        &fixed_point_quantize_stochastic_mask,
+        "Fixed Point Number Stochastic Quantization (CUDA)");
+  m.def("block_quantize_stochastic", &block_quantize_stochastic,
+        "Block Floating Point Number Stochastic Quantization (CUDA)");
+  m.def("block_quantize_sim_stochastic", &block_quantize_sim_stochastic,
+        "Block Floating Point Number Stochastic Quantization (CUDA)");
+  m.def("float_quantize_stochastic", &float_quantize_stochastic,
+        "Low-Bitwidth Floating Point Number Stochastic Quantization (CUDA)");
+  m.def("fixed_point_quantize_nearest", &fixed_point_quantize_nearest,
+        "Fixed Point Number Nearest Neighbor Quantization (CUDA)");
+  m.def("fixed_point_quantize_nearest_mask", &fixed_point_quantize_nearest_mask,
+        "Fixed Point Number Nearest Neighbor Quantization (CUDA)");
+  m.def("block_quantize_nearest", &block_quantize_nearest,
+        "Block Floating Point Number Nearest Neighbor Quantization (CUDA)");
+  m.def("block_quantize_sim_nearest", &block_quantize_sim_nearest,
+        "Block Floating Point Number Stochastic Quantization (CUDA)");
+  m.def("float_quantize_nearest", &float_quantize_nearest,
+        "Low-Bitwidth Floating Point Number Nearest Neighbor Quantization "
+        "(CUDA)");
 }

--- a/qtorch/quant/quant_cuda/quant_cuda.h
+++ b/qtorch/quant/quant_cuda/quant_cuda.h
@@ -9,7 +9,8 @@ using namespace at;
  * having a symmeric number range.
  * Stochastic Rounding.
  **/
-Tensor fixed_point_quantize_stochastic_cuda(Tensor a, int wl, int fl, bool use_clamp, bool symmetric);
+Tensor fixed_point_quantize_stochastic_cuda(Tensor a, int wl, int fl,
+                                            bool use_clamp, bool symmetric);
 
 /**
  * quantize a FloatTensor into fixed point number with word length [wl]
@@ -17,23 +18,28 @@ Tensor fixed_point_quantize_stochastic_cuda(Tensor a, int wl, int fl, bool use_c
  * having a symmeric number range.
  * Nearest Rounding.
  **/
-Tensor fixed_point_quantize_nearest_cuda(Tensor a, int wl, int fl, bool use_clamp, bool symmetric);
+Tensor fixed_point_quantize_nearest_cuda(Tensor a, int wl, int fl,
+                                         bool use_clamp, bool symmetric);
 
 /**
  * quantize a FloatTensor into fixed point number with word length [wl]
- * and fractional bits [fl], clamp the over/underflow number and recording the clamping into a mask,
- * with the option of having a symmetric number range
+ * and fractional bits [fl], clamp the over/underflow number and recording the
+ *clamping into a mask, with the option of having a symmetric number range
  * Stochastic Rounding.
  **/
-std::tuple<Tensor, Tensor> fixed_point_quantize_stochastic_mask_cuda(Tensor a, int wl, int fl, bool symmetric);
+std::tuple<Tensor, Tensor>
+fixed_point_quantize_stochastic_mask_cuda(Tensor a, int wl, int fl,
+                                          bool symmetric);
 
 /**
  * quantize a FloatTensor into fixed point number with word length [wl]
- * and fractional bits [fl], clamp the over/underflow number and recording the clamping into a mask,
- * with the option of having a symmetric number range
+ * and fractional bits [fl], clamp the over/underflow number and recording the
+ *clamping into a mask, with the option of having a symmetric number range
  * Nearest Rounding.
  **/
-std::tuple<Tensor, Tensor> fixed_point_quantize_nearest_mask_cuda(Tensor a, int wl, int fl, bool symmetric);
+std::tuple<Tensor, Tensor>
+fixed_point_quantize_nearest_mask_cuda(Tensor a, int wl, int fl,
+                                       bool symmetric);
 
 /**
  * quantize a FloatTensor into fixed point number with word length [wl]

--- a/qtorch/quant/quant_cuda/quant_cuda.h
+++ b/qtorch/quant/quant_cuda/quant_cuda.h
@@ -10,7 +10,8 @@ using namespace at;
  * Stochastic Rounding.
  **/
 Tensor fixed_point_quantize_stochastic_cuda(Tensor a, int wl, int fl,
-                                            bool use_clamp, bool symmetric);
+                                            bool use_clamp, bool symmetric,
+                                            bool dynamic_precision);
 
 /**
  * quantize a FloatTensor into fixed point number with word length [wl]
@@ -19,7 +20,8 @@ Tensor fixed_point_quantize_stochastic_cuda(Tensor a, int wl, int fl,
  * Nearest Rounding.
  **/
 Tensor fixed_point_quantize_nearest_cuda(Tensor a, int wl, int fl,
-                                         bool use_clamp, bool symmetric);
+                                         bool use_clamp, bool symmetric,
+                                         bool dynamic_precision);
 
 /**
  * quantize a FloatTensor into fixed point number with word length [wl]
@@ -27,9 +29,8 @@ Tensor fixed_point_quantize_nearest_cuda(Tensor a, int wl, int fl,
  *clamping into a mask, with the option of having a symmetric number range
  * Stochastic Rounding.
  **/
-std::tuple<Tensor, Tensor>
-fixed_point_quantize_stochastic_mask_cuda(Tensor a, int wl, int fl,
-                                          bool symmetric);
+std::tuple<Tensor, Tensor> fixed_point_quantize_stochastic_mask_cuda(
+    Tensor a, int wl, int fl, bool symmetric, bool dynamic_precision);
 
 /**
  * quantize a FloatTensor into fixed point number with word length [wl]
@@ -38,8 +39,8 @@ fixed_point_quantize_stochastic_mask_cuda(Tensor a, int wl, int fl,
  * Nearest Rounding.
  **/
 std::tuple<Tensor, Tensor>
-fixed_point_quantize_nearest_mask_cuda(Tensor a, int wl, int fl,
-                                       bool symmetric);
+fixed_point_quantize_nearest_mask_cuda(Tensor a, int wl, int fl, bool symmetric,
+                                       bool dynamic_precision);
 
 /**
  * quantize a FloatTensor into fixed point number with word length [wl]

--- a/qtorch/quant/quant_cuda/quant_kernel.h
+++ b/qtorch/quant/quant_cuda/quant_kernel.h
@@ -1,54 +1,40 @@
 #include <stdint.h>
 
-__global__ void fixed_point_quantize_kernel_stochastic(float *__restrict__ a,
-                                                       float *__restrict__ r,
-                                                       float *o, int size,
-                                                       int sigma, bool clamp,
-                                                       float t_min, float t_max);
+__global__ void fixed_point_quantize_kernel_stochastic(
+    float *__restrict__ a, float *__restrict__ r, float *o, int size, int sigma,
+    bool clamp, float t_min, float t_max);
 
 __global__ void fixed_point_quantize_kernel_nearest(float *__restrict__ a,
                                                     float *o, int size,
                                                     int sigma, bool clamp,
                                                     float t_min, float t_max);
 
-__global__ void fixed_point_quantize_kernel_mask_stochastic(float *__restrict__ a,
-                                                            float *__restrict__ r,
-                                                            float *o, uint8_t *mask,
-                                                            int size, int sigma,
-                                                            float t_min, float t_max);
+__global__ void fixed_point_quantize_kernel_mask_stochastic(
+    float *__restrict__ a, float *__restrict__ r, float *o, uint8_t *mask,
+    int size, int sigma, float t_min, float t_max);
 
-__global__ void fixed_point_quantize_kernel_mask_nearest(float *__restrict__ a,
-                                                         float *o, uint8_t *mask,
-                                                         int size, int sigma,
-                                                         float t_min, float t_max);
+__global__ void
+fixed_point_quantize_kernel_mask_nearest(float *__restrict__ a, float *o,
+                                         uint8_t *mask, int size, int sigma,
+                                         float t_min, float t_max);
 
 __global__ void float_kernel_stochastic(float *__restrict__ a,
-                                        int *__restrict__ r,
-                                        float *o, int size,
+                                        int *__restrict__ r, float *o, int size,
                                         int man_bits, int exp_bits);
 
-__global__ void float_kernel_nearest(float *__restrict__ a,
-                                     float *o, int size,
+__global__ void float_kernel_nearest(float *__restrict__ a, float *o, int size,
                                      int man_bits, int exp_bits);
 
 __global__ void block_kernel_stochastic(float *__restrict__ a,
-                                        int *__restrict__ r,
-                                        float *o, int size,
-                                        float *max_entry,
-                                        int man_bits);
+                                        int *__restrict__ r, float *o, int size,
+                                        float *max_entry, int man_bits);
 
-__global__ void block_kernel_nearest(float *__restrict__ a,
-                                     float *o, int size,
-                                     float *max_entry,
-                                     int man_bits);
+__global__ void block_kernel_nearest(float *__restrict__ a, float *o, int size,
+                                     float *max_entry, int man_bits);
 
 __global__ void block_kernel_sim_stochastic(float *__restrict__ a,
-                                            float *__restrict__ r,
-                                            float *o, int size,
-                                            float *max_entry,
-                                            int wl);
+                                            float *__restrict__ r, float *o,
+                                            int size, float *max_entry, int wl);
 
-__global__ void block_kernel_sim_nearest(float *__restrict__ a,
-                                         float *o, int size,
-                                         float *max_entry,
-                                         int wl);
+__global__ void block_kernel_sim_nearest(float *__restrict__ a, float *o,
+                                         int size, float *max_entry, int wl);

--- a/qtorch/quant/quant_cuda/sim_helper.cu
+++ b/qtorch/quant/quant_cuda/sim_helper.cu
@@ -3,22 +3,22 @@
 
 __device__ __forceinline__ float round_helper(float a, float r) {
   // return floor(a+r);
-  return nearbyint(a+r-0.5);
+  return nearbyint(a + r - 0.5);
 }
 
 __device__ __forceinline__ float round(float a, float r, int sigma) {
-  a = ldexp(a, -sigma); 
+  a = ldexp(a, -sigma);
   a = round_helper(a, r);
   a = ldexp(a, sigma);
   return a;
 }
 
 __device__ __forceinline__ float nearest_round(float a, int sigma) {
-  a = ldexp(a, -sigma); 
+  a = ldexp(a, -sigma);
   // a = nearbyint(a);
   a = round(a);
   // a = floor(a+0.5);
-  //a = ceil(a-0.5);
+  // a = ceil(a-0.5);
   a = ldexp(a, sigma);
   return a;
 }

--- a/qtorch/quant/quant_function.py
+++ b/qtorch/quant/quant_function.py
@@ -53,6 +53,7 @@ def quantizer(
     backward_number=None,
     forward_rounding="stochastic",
     backward_rounding="stochastic",
+    dynamic_precision=False,
     clamping_grad_zero=False,
     backward_hooks=[],
 ):
@@ -90,6 +91,7 @@ def quantizer(
             elif type(forward_number) == FixedPoint:
                 forward_quant = lambda x, quant_module: quant_module.fixed_point_quantize_nearest(
                     x, forward_number.wl, forward_number.fl, forward_number.clamp, forward_number.symmetric,
+                    dynamic_precision,
                 )
             elif type(forward_number) == FloatingPoint:
                 forward_quant = lambda x, quant_module: quant_module.float_quantize_nearest(
@@ -103,6 +105,7 @@ def quantizer(
             elif type(forward_number) == FixedPoint:
                 forward_quant = lambda x, quant_module: quant_module.fixed_point_quantize_stochastic(
                     x, forward_number.wl, forward_number.fl, forward_number.clamp, forward_number.symmetric,
+                    dynamic_precision,
                 )
             elif type(forward_number) == FloatingPoint:
                 forward_quant = lambda x, quant_module: quant_module.float_quantize_stochastic(
@@ -115,11 +118,11 @@ def quantizer(
             ), "must use clamping if zeroing out clamped gradient"
             if forward_rounding == "nearest":
                 forward_quant = lambda x, quant_module: quant_module.fixed_point_quantize_nearest_mask(
-                    x, forward_number.wl, forward_number.fl, forward_number.symmetric
+                    x, forward_number.wl, forward_number.fl, forward_number.symmetric, dynamic_precision
                 )
             elif forward_rounding == "stochastic":
                 forward_quant = lambda x, quant_module: quant_module.fixed_point_quantize_stochastic_mask(
-                    x, forward_number.wl, forward_number.fl, forward_number.symmetric
+                    x, forward_number.wl, forward_number.fl, forward_number.symmetric, dynamic_precision
                 )
         else:
             raise ValueError("zeroing clamping gradient only support fixed point.")
@@ -132,6 +135,7 @@ def quantizer(
         elif type(backward_number) == FixedPoint:
             backward_quant = lambda a, quant_module: quant_module.fixed_point_quantize_nearest(
                 a, backward_number.wl, backward_number.fl, backward_number.clamp, backward_number.symmetric,
+                dynamic_precision,
             )
         elif type(backward_number) == FloatingPoint:
             backward_quant = lambda a, quant_module: quant_module.float_quantize_nearest(

--- a/qtorch/quant/quant_module.py
+++ b/qtorch/quant/quant_module.py
@@ -1,5 +1,6 @@
 import torch
 import torch.nn as nn
+from qtorch import BlockFloatingPoint, FloatingPoint
 from .quant_function import *
 import numpy as np
 
@@ -13,10 +14,15 @@ class Quantizer(nn.Module):
         backward_number=None,
         forward_rounding="stochastic",
         backward_rounding="stochastic",
+        dynamic_precision=False,
     ):
+        if dynamic_precision == True:
+            if type(forward_number) == FloatingPoint or type(forward_number) == BlockFloatingPoint:
+                print("Not support DYNAMIC PRECISION in Floating point")
+
         super(Quantizer, self).__init__()
         self.quantize = quantizer(
-            forward_number, backward_number, forward_rounding, backward_rounding
+            forward_number, backward_number, forward_rounding, backward_rounding, dynamic_precision,
         )
 
     def forward(self, x):


### PR DESCRIPTION
  - This Quantization is based on https://github.com/arkainoh/fixedpoint/blob/master/src/cpp/fixedpoint.h
  - Different quantization is applied for each layer
    - Dynamic fractional length for each layer
  - Set 'dynamic_precision' as True for use
    - example)
      Q = Quantizer(forward_number=forward_num,
        forward_rounding="stochastic",
        dynamic_precision=True)