### PR TITLE
Add wheel to the requirements

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,3 +1,4 @@
 sphinx>=1.4
 ipykernel
 nbsphinx
+wheel


### PR DESCRIPTION
Building qtorch using pip fails due to the missing package: wheel
- Add it to the requirements so that `pip install .` builds qtoch