### PR TITLE
[BUG FIXED] Fix the package re is not imported

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -1,4 +1,5 @@
 from setuptools import setup, find_packages
+import re
 
 try:
     import torch


### PR DESCRIPTION
Hi there,
I fix the bug where the package `re` is not imported when the pytorch is a dev version.

L16: `        install_require for install_require in install_requires if "torch" != re.split(r"(=|<|>)", install_require)[0]`