### PR TITLE
Make sure that Ninja for cpp loading is part of requirements

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,3 +1,4 @@
 sphinx>=1.4
 ipykernel
 nbsphinx
+Ninja


### PR DESCRIPTION
Title says it all! Without `Ninja` installed, received an error that loading C++ modules requires `Ninja`.