### PR TITLE
Enablement on ROCm

### DIFF
--- a/qtorch/quant/quant_cuda/bit_helper.cu
+++ b/qtorch/quant/quant_cuda/bit_helper.cu
@@ -1,8 +1,10 @@
 #define FLOAT_TO_BITS(x) (*reinterpret_cast<unsigned int*>(x))
 #define BITS_TO_FLOAT(x) (*reinterpret_cast<float*>(x))
 
-#ifdef __HIP_PLATFORM_AMD__
+#ifdef __HIP__
+#ifndef __forceinline__
 #define __forceinline__ inline __attribute__((always_inline))
+#endif
 #endif
 
 __device__ __forceinline__ unsigned int extract_exponent(float *a) {

--- a/qtorch/quant/quant_cuda/bit_helper.cu
+++ b/qtorch/quant/quant_cuda/bit_helper.cu
@@ -1,6 +1,10 @@
 #define FLOAT_TO_BITS(x) (*reinterpret_cast<unsigned int*>(x))
 #define BITS_TO_FLOAT(x) (*reinterpret_cast<float*>(x))
 
+#ifdef __HIP_PLATFORM_AMD__
+#define __forceinline__ inline __attribute__((always_inline))
+#endif
+
 __device__ __forceinline__ unsigned int extract_exponent(float *a) {
   unsigned int temp = *(reinterpret_cast<unsigned int*>(a));
   temp = (temp << 1 >> 24); // single preciision, 1 sign bit, 23 mantissa bits

--- a/qtorch/quant/quant_cuda/fixed_point_kernel.cu
+++ b/qtorch/quant/quant_cuda/fixed_point_kernel.cu
@@ -1,6 +1,9 @@
 #include "quant_kernel.h"
 #include "sim_helper.cu"
 
+#ifdef __HIP_PLATFORM_AMD__
+#define __forceinline__ inline __attribute__((always_inline))
+#endif
 
 template <typename T>
 __device__ __forceinline__ T clamp_helper(T a, T min, T max) {

--- a/qtorch/quant/quant_cuda/fixed_point_kernel.cu
+++ b/qtorch/quant/quant_cuda/fixed_point_kernel.cu
@@ -1,8 +1,10 @@
 #include "quant_kernel.h"
 #include "sim_helper.cu"
 
-#ifdef __HIP_PLATFORM_AMD__
+#ifdef __HIP__
+#ifndef __forceinline__
 #define __forceinline__ inline __attribute__((always_inline))
+#endif
 #endif
 
 template <typename T>

--- a/qtorch/quant/quant_function.py
+++ b/qtorch/quant/quant_function.py
@@ -28,6 +28,7 @@ if torch.cuda.is_available():
             os.path.join(current_path, "quant_cuda/fixed_point_kernel.cu"),
             os.path.join(current_path, "quant_cuda/quant.cu"),
         ],
+        extra_include_paths=[os.path.join(current_path, "quant_cuda")],
     )
 else:
     quant_cuda = quant_cpu


### PR DESCRIPTION
This PR contains the below two changes

1. __forceinline__ needs inline and always_inline on ROCm
2. extra_include_paths is required for the hipification of quant_cuda header files.
